### PR TITLE
Copilot suggestions: Fix unit tests, ECT curl retries, and missing 120km config vars

### DIFF
--- a/.github/actions/validate-ect/action.yml
+++ b/.github/actions/validate-ect/action.yml
@@ -50,7 +50,7 @@ runs:
         source .github/test-cases/${{ inputs.test-case }}/config.env
         SUMMARY="${ECT_SUMMARY_PREFIX}.nc"
         echo "Downloading ${SUMMARY} from ${DATA_REPO}..."
-        HTTP_CODE=$(curl -sL -w "%{http_code}" \
+        HTTP_CODE=$(curl --retry 5 --retry-delay 5 -sL -w "%{http_code}" \
           "https://github.com/${DATA_REPO}/raw/main/${SUMMARY}" \
           -o "${SUMMARY}")
         if [ "${HTTP_CODE}" != "200" ]; then

--- a/.github/test-cases/120km/config.env
+++ b/.github/test-cases/120km/config.env
@@ -18,3 +18,7 @@ RESTART_INTERVAL=0_02:00:00
 # Run timeout in minutes
 RUN_TIMEOUT=30
 
+# Test data configuration
+RESOLUTION=120km
+DATA_REPO=NCAR/mpas-ci-data
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,6 +43,11 @@ jobs:
       PFUNIT_PATH: ${{ github.workspace }}/pFUnit
 
     steps:
+      - name: Install GCC toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-${{ matrix.gcc-version }} g++-${{ matrix.gcc-version }} gfortran-${{ matrix.gcc-version }}
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
- Install GCC toolchain in unit-tests.yml (fixes pFUnit failures on ubuntu-latest)
- Add curl retry flags to validate-ect summary download
- Add missing RESOLUTION and DATA_REPO to 120km/config.env

Cherry-picked from feature-ci-test-cases (528264834).


