### PR TITLE
Add NVHPC subset CI workflow

### DIFF
--- a/.github/actions/validate-logs/action.yml
+++ b/.github/actions/validate-logs/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Comma-separated list of expected config names; missing ones shown as NO_LOG'
     required: false
     default: ''
+  allow-missing:
+    description: 'Do not fail when some configurations have no log files (default: true for backward compat)'
+    required: false
+    default: 'true'
 
 outputs:
   status:
@@ -61,7 +65,10 @@ runs:
         fi
 
         ARGS=("${SCRIPT}" "${{ inputs.logs-path }}" "${{ inputs.reference-log }}")
-        ARGS+=(--allow-missing --summary-file "$GITHUB_STEP_SUMMARY")
+        ARGS+=(--summary-file "$GITHUB_STEP_SUMMARY")
+        if [ "${{ inputs.allow-missing }}" = "true" ]; then
+          ARGS+=(--allow-missing)
+        fi
 
         if [ -n "${{ inputs.log-filter }}" ]; then
           ARGS+=(--filter "${{ inputs.log-filter }}")

--- a/.github/workflows/test-nvhpc.yml
+++ b/.github/workflows/test-nvhpc.yml
@@ -1,0 +1,127 @@
+# Subset CI: NVHPC compiler only (no GPU)
+# Quick validation that NVHPC builds and runs on GitHub Actions runners.
+# Tests two MPI libraries (mpich3 + openmpi) with SMIOL at 1 MPI rank.
+#
+# For GPU testing, see test-cirrus-nvhpc.yml.
+# For full matrix testing, see test-ga-nogpu.yml.
+
+name: "NVHPC (subset)"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master, develop]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        mpi: [mpich3, openmpi]
+
+    name: Build (nvhpc, ${{ matrix.mpi }}, smiol)
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/ncarcisl/cisldev-x86_64-almalinux9-nvhpc-${{ matrix.mpi }}:devel
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Build MPAS-A
+        uses: ./.github/actions/build-mpas
+        with:
+          compiler: nvhpc
+          use-pio: 'false'
+
+      - name: Upload executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: exe-nvhpc-${{ matrix.mpi }}-smiol
+          path: atmosphere_model
+          retention-days: 1
+
+  run:
+    needs: build
+    if: ${{ !cancelled() && needs.build.result != 'cancelled' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        mpi: [mpich3, openmpi]
+
+    name: Run 1proc (nvhpc, ${{ matrix.mpi }}, smiol)
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/ncarcisl/cisldev-x86_64-almalinux9-nvhpc-${{ matrix.mpi }}:devel
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download executable
+        id: download
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: exe-nvhpc-${{ matrix.mpi }}-smiol
+
+      - name: Run MPAS-A
+        if: steps.download.outcome == 'success'
+        uses: ./.github/actions/run-mpas
+        with:
+          executable: ./atmosphere_model
+          num-procs: '1'
+          mpi-impl: ${{ matrix.mpi != 'openmpi' && 'mpich' || 'openmpi' }}
+          working-dir: run-nvhpc-${{ matrix.mpi }}-smiol
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        if: always() && steps.download.outcome == 'success'
+        with:
+          name: logs-1proc-nvhpc-${{ matrix.mpi }}-nogpu-smiol
+          path: run-nvhpc-${{ matrix.mpi }}-smiol/log.*
+          retention-days: 5
+
+  validate:
+    needs: run
+    if: always()
+    runs-on: ubuntu-latest
+    name: Validate Results
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Download all logs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: logs-*
+          path: logs
+
+      - name: Validate 1-proc logs against reference
+        uses: ./.github/actions/validate-logs
+        with:
+          logs-path: logs
+          log-filter: 1proc
+          reference-log: .github/test-cases/240km/reference_log.atmosphere.0000.out
+          expected-configs: >-
+            logs-1proc-nvhpc-mpich3-nogpu-smiol,
+            logs-1proc-nvhpc-openmpi-nogpu-smiol
+
+  cleanup:
+    needs: [run, validate]
+    if: always()
+    runs-on: ubuntu-latest
+    name: Cleanup
+
+    steps:
+      - name: Delete artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: exe-*
+          failOnError: false

--- a/.github/workflows/test-nvhpc.yml
+++ b/.github/workflows/test-nvhpc.yml
@@ -11,6 +11,8 @@ on:
   workflow_dispatch:
   push:
     branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
 
 jobs:
   build:
@@ -59,14 +61,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download executable
-        id: download
         uses: actions/download-artifact@v4
-        continue-on-error: true
         with:
           name: exe-nvhpc-${{ matrix.mpi }}-smiol
 
       - name: Run MPAS-A
-        if: steps.download.outcome == 'success'
         uses: ./.github/actions/run-mpas
         with:
           executable: ./atmosphere_model
@@ -76,7 +75,7 @@ jobs:
 
       - name: Upload logs
         uses: actions/upload-artifact@v4
-        if: always() && steps.download.outcome == 'success'
+        if: always()
         with:
           name: logs-1proc-nvhpc-${{ matrix.mpi }}-nogpu-smiol
           path: run-nvhpc-${{ matrix.mpi }}-smiol/log.*
@@ -109,6 +108,7 @@ jobs:
           logs-path: logs
           log-filter: 1proc
           reference-log: .github/test-cases/240km/reference_log.atmosphere.0000.out
+          allow-missing: 'false'
           expected-configs: >-
             logs-1proc-nvhpc-mpich3-nogpu-smiol,
             logs-1proc-nvhpc-openmpi-nogpu-smiol


### PR DESCRIPTION
## Summary
- Adds `test-nvhpc.yml` -- NVHPC-only subset workflow (no GPU)
- Builds nvhpc with mpich3 and openmpi (SMIOL, 1 MPI rank)
- Validates logs against reference output
- Triggers on push to master/develop and workflow_dispatch

## Test plan
- [ ] Trigger manually via Actions tab after merge
- [ ] Verify build/run/validate for both mpich3 and openmpi