### PR TITLE
Fix git diff bug that prevented restart push to mpas-ci-data

### DIFF
--- a/.github/workflows/ect-ensemble-gen.yml
+++ b/.github/workflows/ect-ensemble-gen.yml
@@ -201,10 +201,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          if git diff --quiet "${RESTART_FILE}" 2>/dev/null; then
+          git add "${RESTART_FILE}"
+          if git diff --cached --quiet; then
             echo "Restart file unchanged — skipping push."
           else
-            git add "${RESTART_FILE}"
             git commit -m "Update spin-up restart: ${RESTART_FILE}
 
           Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"


### PR DESCRIPTION
## Summary

Fix a bug in the ECT ensemble generation spinup job that silently skips pushing the restart file to `mpas-ci-data`.

The "Push restart to mpas-ci-data" step uses `git diff --quiet` to check if the restart file changed. But `git diff` only compares **tracked** files. When the restart file is **new** (untracked), `git diff` always reports "no changes" and the push is skipped. This is why `mpas_ect_summary_120km_restart.nc` has never appeared in `mpas-ci-data`.

**Fix:** Stage the file first (`git add`), then use `git diff --cached --quiet` to detect changes in the index. This correctly handles both new and modified files.

This fix was intended for PR #11 but was pushed after the merge. Cherry-picked here as a standalone fix.

## Test plan

- [ ] Merge, then re-run `ect-ensemble-gen.yml` on master
- [ ] Verify `mpas_ect_summary_120km_restart.nc` appears in `NCAR/mpas-ci-data`
