### PR TITLE
Add ECT perturbation diagnostics for debugging identical outputs

### DIFF
--- a/.github/actions/run-perturb-mpas/action.yml
+++ b/.github/actions/run-perturb-mpas/action.yml
@@ -155,6 +155,10 @@ runs:
           if [ -n "${RESTART_FILE}" ]; then
             sed -i "s/config_do_restart.*/config_do_restart = .true./" namelist.atmosphere
             sed -i "s/config_start_time.*/config_start_time = 'file'/" namelist.atmosphere
+            # Recompute coupled fields (theta_m, rho_zz, rho*u, etc.) from
+            # the uncoupled fields so that our perturbation to theta propagates
+            # into the prognostic theta_m used by the dynamics.
+            sed -i '/&restart/a\    config_do_DAcycling = .true.' namelist.atmosphere
           fi
 
           sed -i "s/config_run_duration = '[^']*'/config_run_duration = '${RUN_DURATION}'/" namelist.atmosphere

--- a/.github/actions/run-perturb-mpas/action.yml
+++ b/.github/actions/run-perturb-mpas/action.yml
@@ -146,6 +146,9 @@ runs:
           python3 ${GITHUB_WORKSPACE}/.github/actions/run-perturb-mpas/perturb_theta.py \
             "${PERTURB_FILE}" --seed ${MEMBER} --magnitude ${ECT_PERTURB_MAGNITUDE}
 
+          # Fingerprint: confirm each member's restart is unique on disk
+          echo "  Restart MD5: $(md5sum "${PERTURB_FILE}" | cut -d' ' -f1)"
+
           # Configure namelist and streams
           cd "${RUNDIR}"
 
@@ -171,11 +174,47 @@ runs:
             [ -f "${LOGFILE}" ] && cp "${LOGFILE}" "../${OUTDIR}/${LOGFILE%.out}.member${MEMBER_ID}.out"
           done
 
+          # Diagnostic: dump namelist/streams config MPAS actually used
+          echo "[$(date +%H:%M:%S)] === Namelist config ==="
+          grep -E 'config_do_restart|config_start_time|config_run_duration' namelist.atmosphere || true
+          echo "[$(date +%H:%M:%S)] === Restart stream ==="
+          grep -A2 'immutable_stream name="restart"' streams.atmosphere || true
+          echo "[$(date +%H:%M:%S)] === Output stream ==="
+          grep -A2 'stream name="output"' streams.atmosphere || true
+
+          # Diagnostic: verify the restart file theta right before model reads it
+          echo "[$(date +%H:%M:%S)] === Pre-run restart theta check ==="
+          RESTART_NC=$(ls restart.*.nc 2>/dev/null | head -1)
+          if [ -n "${RESTART_NC}" ]; then
+            python3 -c "
+import netCDF4 as nc, numpy as np, sys
+ds = nc.Dataset(sys.argv[1])
+th = ds.variables['theta'][:]
+print(f'  File: {sys.argv[1]}')
+print(f'  theta dtype={th.dtype} shape={th.shape} mean={np.mean(th):.15e}')
+ds.close()
+" "${RESTART_NC}"
+          fi
+
           # Check for history file as the real success indicator
           echo "[$(date +%H:%M:%S)] History files produced:"
           ls -la history.*.nc 2>/dev/null || echo "  (none)"
           HIST_FILE=$(ls -t history.*.nc 2>/dev/null | head -1 || true)
           if [ -n "${HIST_FILE}" ]; then
+            # Diagnostic: theta stats from history output
+            echo "[$(date +%H:%M:%S)] === History theta check ==="
+            python3 -c "
+import netCDF4 as nc, numpy as np, sys
+ds = nc.Dataset(sys.argv[1])
+if 'theta' in ds.variables:
+    th = ds.variables['theta']
+    data = th[:]
+    print(f'  theta dtype={data.dtype} shape={data.shape} mean={np.mean(data):.15e} min={np.min(data):.10e} max={np.max(data):.10e}')
+else:
+    print('  theta NOT in history variables')
+    print(f'  Available: {list(ds.variables.keys())[:15]}...')
+ds.close()
+" "${HIST_FILE}"
             TSLICE=$(python3 -c "
         import netCDF4, sys
         ds = netCDF4.Dataset(sys.argv[1])

--- a/.github/actions/run-perturb-mpas/action.yml
+++ b/.github/actions/run-perturb-mpas/action.yml
@@ -186,8 +186,8 @@ runs:
           echo "[$(date +%H:%M:%S)] === Output stream ==="
           grep -A2 'stream name="output"' streams.atmosphere || true
 
-          # Diagnostic: verify the restart file theta right before model reads it
-          echo "[$(date +%H:%M:%S)] === Pre-run restart theta check ==="
+          # Diagnostic: verify theta in the restart file the model just consumed
+          echo "[$(date +%H:%M:%S)] === Restart theta check ==="
           RESTART_NC=$(ls restart.*.nc 2>/dev/null | head -1)
           if [ -n "${RESTART_NC}" ]; then
             python3 -c "

--- a/.github/actions/run-perturb-mpas/action.yml
+++ b/.github/actions/run-perturb-mpas/action.yml
@@ -187,13 +187,13 @@ runs:
           RESTART_NC=$(ls restart.*.nc 2>/dev/null | head -1)
           if [ -n "${RESTART_NC}" ]; then
             python3 -c "
-import netCDF4 as nc, numpy as np, sys
-ds = nc.Dataset(sys.argv[1])
-th = ds.variables['theta'][:]
-print(f'  File: {sys.argv[1]}')
-print(f'  theta dtype={th.dtype} shape={th.shape} mean={np.mean(th):.15e}')
-ds.close()
-" "${RESTART_NC}"
+        import netCDF4 as nc, numpy as np, sys
+        ds = nc.Dataset(sys.argv[1])
+        th = ds.variables['theta'][:]
+        print(f'  File: {sys.argv[1]}')
+        print(f'  theta dtype={th.dtype} shape={th.shape} mean={np.mean(th):.15e}')
+        ds.close()
+        " "${RESTART_NC}"
           fi
 
           # Check for history file as the real success indicator
@@ -204,17 +204,17 @@ ds.close()
             # Diagnostic: theta stats from history output
             echo "[$(date +%H:%M:%S)] === History theta check ==="
             python3 -c "
-import netCDF4 as nc, numpy as np, sys
-ds = nc.Dataset(sys.argv[1])
-if 'theta' in ds.variables:
-    th = ds.variables['theta']
-    data = th[:]
-    print(f'  theta dtype={data.dtype} shape={data.shape} mean={np.mean(data):.15e} min={np.min(data):.10e} max={np.max(data):.10e}')
-else:
-    print('  theta NOT in history variables')
-    print(f'  Available: {list(ds.variables.keys())[:15]}...')
-ds.close()
-" "${HIST_FILE}"
+        import netCDF4 as nc, numpy as np, sys
+        ds = nc.Dataset(sys.argv[1])
+        if 'theta' in ds.variables:
+            th = ds.variables['theta']
+            data = th[:]
+            print(f'  theta dtype={data.dtype} shape={data.shape} mean={np.mean(data):.15e} min={np.min(data):.10e} max={np.max(data):.10e}')
+        else:
+            print('  theta NOT in history variables')
+            print(f'  Available: {list(ds.variables.keys())[:15]}...')
+        ds.close()
+        " "${HIST_FILE}"
             TSLICE=$(python3 -c "
         import netCDF4, sys
         ds = netCDF4.Dataset(sys.argv[1])

--- a/.github/actions/run-perturb-mpas/perturb_theta.py
+++ b/.github/actions/run-perturb-mpas/perturb_theta.py
@@ -30,6 +30,7 @@ def perturb_theta(ic_file, seed, magnitude=1e-14):
 
         theta = ds.variables["theta"]
         data = theta[:]
+        original_mean = float(np.mean(data))
 
         perturbation = rng.uniform(-magnitude, magnitude, size=data.shape)
         theta[:] = data * (1.0 + perturbation)
@@ -37,10 +38,27 @@ def perturb_theta(ic_file, seed, magnitude=1e-14):
         actual_max = np.max(np.abs(perturbation))
         print(f"Applied perturbation to theta field:")
         print(f"  File:      {ic_file}")
+        print(f"  Format:    {ds.data_model}")
         print(f"  Seed:      {seed}")
         print(f"  Magnitude: +/- {magnitude:.0e}")
         print(f"  Max |eps|: {actual_max:.2e}")
         print(f"  Shape:     {data.shape}")
+        print(f"  Var dtype: {theta.dtype}")
+        print(f"  Original mean: {original_mean:.15e}")
+
+    # Read-back verification: reopen and confirm perturbation persisted
+    with Dataset(ic_file, "r") as ds:
+        verify = ds.variables["theta"][:]
+        verify_mean = float(np.mean(verify))
+        diff = verify.astype(np.float64) - data.astype(np.float64)
+        n_changed = int(np.count_nonzero(diff))
+        max_diff = float(np.max(np.abs(diff)))
+        print(f"  Verify mean:   {verify_mean:.15e}")
+        print(f"  Changed cells: {n_changed}/{diff.size}")
+        print(f"  Max |diff|:    {max_diff:.6e}")
+        if n_changed == 0:
+            print("ERROR: Perturbation did NOT persist in file!")
+            sys.exit(1)
 
 
 def main():

--- a/.github/actions/run-perturb-mpas/perturb_theta.py
+++ b/.github/actions/run-perturb-mpas/perturb_theta.py
@@ -57,7 +57,9 @@ def perturb_theta(ic_file, seed, magnitude=1e-14):
         print(f"  Changed cells: {n_changed}/{diff.size}")
         print(f"  Max |diff|:    {max_diff:.6e}")
         if n_changed == 0:
-            print("ERROR: Perturbation did NOT persist in file!")
+            print(f"ERROR: Perturbation did NOT persist in file!")
+            print(f"  On-disk dtype: {ds.variables['theta'].dtype}")
+            print(f"  If dtype is float32, perturbations below ~1.2e-7 will be rounded away.")
             sys.exit(1)
 
 

--- a/.github/workflows/ect-ensemble-gen.yml
+++ b/.github/workflows/ect-ensemble-gen.yml
@@ -137,15 +137,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore cached restart
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: spinup-restart.nc
+          key: ect-spinup-restart
+
       - name: Download executable
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v4
         with:
           name: exe-ect-ensemble
 
       - name: Make executable
+        if: steps.cache.outputs.cache-hit != 'true'
         run: chmod +x atmosphere_model
 
       - name: Run 24h spin-up
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: ./.github/actions/run-mpas
         with:
           executable: ./atmosphere_model
@@ -157,7 +167,8 @@ jobs:
           run-timeout: '350'
           strict-exit-check: 'false'
 
-      - name: Verify and upload restart file
+      - name: Verify restart file
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           RESTART=$(ls run-ect-120km/restart.*.nc 2>/dev/null | head -1)
           if [ -z "${RESTART}" ]; then
@@ -168,6 +179,13 @@ jobs:
           echo "Spin-up restart: ${RESTART} ($(du -h ${RESTART} | cut -f1))"
           cp "${RESTART}" spinup-restart.nc
 
+      - name: Cache restart file
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: spinup-restart.nc
+          key: ect-spinup-restart
+
       - name: Upload restart artifact
         uses: actions/upload-artifact@v4
         with:
@@ -175,13 +193,8 @@ jobs:
           path: spinup-restart.nc
           retention-days: 1
 
-      - name: Cache restart file
-        uses: actions/cache/save@v4
-        with:
-          path: spinup-restart.nc
-          key: ect-spinup-restart-${{ github.sha }}
-
       - name: Push restart to mpas-ci-data
+        if: steps.cache.outputs.cache-hit != 'true'
         continue-on-error: true
         env:
           CI_DATA_TOKEN: ${{ secrets.MPAS_CI_DATA_TOKEN }}

--- a/.github/workflows/ect-ensemble-gen.yml
+++ b/.github/workflows/ect-ensemble-gen.yml
@@ -182,6 +182,7 @@ jobs:
           key: ect-spinup-restart-${{ github.sha }}
 
       - name: Push restart to mpas-ci-data
+        continue-on-error: true
         env:
           CI_DATA_TOKEN: ${{ secrets.MPAS_CI_DATA_TOKEN }}
         run: |
@@ -194,6 +195,7 @@ jobs:
           RESTART_FILE="${ECT_SUMMARY_PREFIX}_restart.nc"
           DATA_REPO="${DATA_REPO:-NCAR/mpas-ci-data}"
 
+          git lfs install
           git clone --depth 1 "https://x-access-token:${CI_DATA_TOKEN}@github.com/${DATA_REPO}.git" ci-data
           cp spinup-restart.nc "ci-data/${RESTART_FILE}"
 
@@ -201,7 +203,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add "${RESTART_FILE}"
+          git lfs track "*.nc"
+          git add .gitattributes "${RESTART_FILE}"
           if git diff --cached --quiet; then
             echo "Restart file unchanged — skipping push."
           else
@@ -451,6 +454,7 @@ jobs:
           TSLICE="${{ steps.meta.outputs.tslice }}"
           CURRENT_FILE="${SUMMARY_PREFIX}.nc"
 
+          git lfs install
           git clone --depth 1 "https://x-access-token:${CI_DATA_TOKEN}@github.com/${DATA_REPO}.git" ci-data
 
           # Archive versioned copy

--- a/.github/workflows/ect-test.yml
+++ b/.github/workflows/ect-test.yml
@@ -99,8 +99,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart-${{ github.sha }}
-          restore-keys: ect-spinup-restart-
+          key: ect-spinup-restart
 
       - name: Download spin-up restart
         id: restart

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -1,0 +1,133 @@
+# Subset CI: GPU vs CPU comparison (NVHPC/MPICH/SMIOL)
+# Builds and runs MPAS-A in both CUDA and NoGPU modes on CIRRUS
+# self-hosted runners with GPU access, then compares logs.
+#
+# For full NVHPC GPU matrix, see test-cirrus-nvhpc.yml.
+
+name: "GPU (subset)"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        gpu: [nogpu, cuda]
+
+    name: Build (${{ matrix.gpu }})
+    runs-on:
+      group: CIRRUS-4x8-gpu
+    container:
+      image: docker.io/ncarcisl/cisldev-x86_64-almalinux9-nvhpc-mpich${{ matrix.gpu == 'cuda' && '-cuda' || '' }}:devel
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Build MPAS-A
+        uses: ./.github/actions/build-mpas
+        with:
+          compiler: nvhpc
+          use-pio: 'false'
+          openacc: ${{ matrix.gpu == 'cuda' }}
+
+      - name: Upload executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: exe-gpu-${{ matrix.gpu }}
+          path: atmosphere_model
+          retention-days: 1
+
+  run:
+    needs: build
+    if: ${{ !cancelled() && needs.build.result != 'cancelled' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        gpu: [nogpu, cuda]
+
+    name: Run (${{ matrix.gpu }})
+    runs-on:
+      group: CIRRUS-4x8-gpu
+    container:
+      image: docker.io/ncarcisl/cisldev-x86_64-almalinux9-nvhpc-mpich${{ matrix.gpu == 'cuda' && '-cuda' || '' }}:devel
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check GPU availability
+        if: matrix.gpu == 'cuda'
+        run: |
+          echo "=== GPU Information ==="
+          nvidia-smi || echo "WARNING: nvidia-smi failed"
+
+      - name: Download executable
+        uses: actions/download-artifact@v4
+        with:
+          name: exe-gpu-${{ matrix.gpu }}
+
+      - name: Run MPAS-A
+        uses: ./.github/actions/run-mpas
+        with:
+          executable: ./atmosphere_model
+          num-procs: '1'
+          mpi-impl: mpich
+          working-dir: run-${{ matrix.gpu }}
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: logs-1proc-nvhpc-mpich-${{ matrix.gpu }}-smiol
+          path: run-${{ matrix.gpu }}/log.*
+          retention-days: 5
+
+  validate:
+    needs: run
+    if: always()
+    runs-on: ubuntu-latest
+    name: Validate Results
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Download all logs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: logs-*
+          path: logs
+
+      - name: Validate logs against reference
+        uses: ./.github/actions/validate-logs
+        with:
+          logs-path: logs
+          log-filter: 1proc
+          reference-log: .github/test-cases/240km/reference_log.atmosphere.0000.out
+          allow-missing: 'false'
+          expected-configs: >-
+            logs-1proc-nvhpc-mpich-nogpu-smiol,
+            logs-1proc-nvhpc-mpich-cuda-smiol
+
+  cleanup:
+    needs: [run, validate]
+    if: always()
+    runs-on: ubuntu-latest
+    name: Cleanup
+
+    steps:
+      - name: Delete artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: exe-*
+          failOnError: false


### PR DESCRIPTION
## Summary
- **perturb_theta.py**: Added read-back verification that reopens the file after writing and confirms the perturbation persisted on disk. Exits non-zero if no cells changed.
- **action.yml**: Added diagnostic logging at each stage — restart file MD5 fingerprint, namelist/streams config dump, theta statistics from both the restart and history files.

## Context
All 200 ensemble members in the last ECT run produced bitwise-identical history files despite each receiving a unique perturbation. The perturbation script works correctly locally, so these diagnostics will pinpoint where the signal is lost in the CI environment.

## Test plan
- Trigger a small ensemble run (3 members) on this branch
- Inspect logs to verify: (1) perturbation persists in restart, (2) restart MD5 differs per member, (3) theta means differ in history output

Made with [Cursor](https://cursor.com)