### PR TITLE
ECT fixes: DA cycling, spin-up caching, 1e-14 perturbation, GPU workflow

### DIFF
--- a/.github/test-cases/ect-120km/config.env
+++ b/.github/test-cases/ect-120km/config.env
@@ -35,7 +35,7 @@ ECT_TEST_RUNS=3
 # Perturbation settings
 # single-precision machine epsilon is ~1.2e-7
 # The paper recommends 1e-14 (requires PRECISION=double).
-ECT_PERTURB_MAGNITUDE=1e-5
+ECT_PERTURB_MAGNITUDE=1e-14
 ECT_PERTURB_VARIABLE=theta
 
 # PyCECT version (git tag from https://github.com/NCAR/PyCECT)


### PR DESCRIPTION
## Summary
- **DA cycling fix**: Enable `config_do_DAcycling` on restart so theta perturbations propagate into the prognostic `theta_m` field, fixing bitwise-identical ensemble outputs
- **Spin-up caching**: Use a stable cache key for the 24h spin-up restart file, avoiding expensive re-runs on every commit
- **Perturbation magnitude**: Set to `1e-14` per the paper recommendation (Price-Broncucia et al. 2025); verified that `theta` is stored as float64 in restart files
- **GPU subset workflow**: New `test-gpu.yml` for NVHPC/MPICH/SMIOL cuda-vs-nogpu comparison on CIRRUS
- **Misc**: YAML parse fix for inline Python in composite action, Git LFS for restart push, Copilot review fixes

## Validation
- 3-member test ensemble succeeded with `1e-14` perturbation (run #23611206904)
- Post-run theta means diverge across members, confirming perturbation propagation
- Ready for full 200-member ensemble generation once merged
