### PR TITLE
Add cross-repo testing for CPU workflows

### DIFF
--- a/.github/actions/validate-ect/action.yml
+++ b/.github/actions/validate-ect/action.yml
@@ -107,6 +107,26 @@ runs:
           exit 1
         fi
 
+    - name: ECT Results
+      if: steps.pycect.outputs.result != ''
+      shell: bash
+      run: |
+        LABEL="${{ inputs.label }}"
+        RESULT="${{ steps.pycect.outputs.result }}"
+        echo "================================"
+        echo "  ECT Result: ${RESULT}"
+        echo "  Label:      ${LABEL}"
+        echo "================================"
+        echo ""
+        # Print the global/regional test lines and final verdict
+        grep -E '(PASSED|FAILED|global|regional|Overall)' pycect_output.txt || true
+        echo ""
+        # Print per-variable standard-mean diagnostics if present
+        if grep -q 'standardized mean' pycect_output.txt; then
+          echo "--- Standardized Mean Summary ---"
+          grep 'standardized mean' pycect_output.txt || true
+        fi
+
     - name: Fail if summary unavailable
       if: steps.summary.outputs.available != 'true'
       shell: bash

--- a/.github/workflows/_test-compiler.yml
+++ b/.github/workflows/_test-compiler.yml
@@ -7,6 +7,10 @@
 
 name: _test-compiler
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   workflow_call:
     inputs:
@@ -58,12 +62,14 @@ jobs:
           repository: ${{ inputs.mpas-repository || github.repository }}
           ref: ${{ inputs.mpas-ref || '' }}
           submodules: 'true'
+          persist-credentials: false
 
       - uses: actions/checkout@v5
         if: ${{ inputs.mpas-repository != '' }}
         with:
           path: _ci
           sparse-checkout: .github
+          persist-credentials: false
 
       - name: Overlay CI infrastructure
         if: ${{ inputs.mpas-repository != '' }}

--- a/.github/workflows/_test-compiler.yml
+++ b/.github/workflows/_test-compiler.yml
@@ -18,6 +18,16 @@ on:
         description: 'MPI implementation (mpich, openmpi)'
         required: true
         type: string
+      mpas-repository:
+        description: 'MPAS source repo (e.g. MPAS-Dev/MPAS-Model). Empty = this repo.'
+        required: false
+        type: string
+        default: ''
+      mpas-ref:
+        description: 'Git ref in the MPAS source repo (branch, tag, SHA)'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   config:
@@ -45,7 +55,22 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          repository: ${{ inputs.mpas-repository || github.repository }}
+          ref: ${{ inputs.mpas-ref || '' }}
           submodules: 'true'
+
+      - uses: actions/checkout@v5
+        if: ${{ inputs.mpas-repository != '' }}
+        with:
+          path: _ci
+          sparse-checkout: .github
+
+      - name: Overlay CI infrastructure
+        if: ${{ inputs.mpas-repository != '' }}
+        shell: bash
+        run: |
+          cp -r _ci/.github . && rm -rf _ci
+          echo "## Source: ${{ inputs.mpas-repository }}@${{ inputs.mpas-ref }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build MPAS-A (double precision)
         uses: ./.github/actions/build-mpas

--- a/.github/workflows/_test-gpu.yml
+++ b/.github/workflows/_test-gpu.yml
@@ -17,6 +17,18 @@ on:
         description: 'MPI implementation (mpich, openmpi)'
         required: true
         type: string
+      # Cross-repo inputs disabled until NCAR security review of running
+      # external code on self-hosted CIRRUS runners is complete.
+      # mpas-repository:
+      #   description: 'MPAS source repo (e.g. MPAS-Dev/MPAS-Model). Empty = this repo.'
+      #   required: false
+      #   type: string
+      #   default: ''
+      # mpas-ref:
+      #   description: 'Git ref in the MPAS source repo (branch, tag, SHA)'
+      #   required: false
+      #   type: string
+      #   default: ''
 
 jobs:
   config:
@@ -53,6 +65,29 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: 'true'
+
+      # Cross-repo checkout disabled until NCAR security review is complete.
+      # To re-enable, restore mpas-repository/mpas-ref inputs above and
+      # replace the checkout step with:
+      #
+      # - uses: actions/checkout@v5
+      #   with:
+      #     repository: ${{ inputs.mpas-repository || github.repository }}
+      #     ref: ${{ inputs.mpas-ref || '' }}
+      #     submodules: 'true'
+      #
+      # - uses: actions/checkout@v5
+      #   if: ${{ inputs.mpas-repository != '' }}
+      #   with:
+      #     path: _ci
+      #     sparse-checkout: .github
+      #
+      # - name: Overlay CI infrastructure
+      #   if: ${{ inputs.mpas-repository != '' }}
+      #   shell: bash
+      #   run: |
+      #     cp -r _ci/.github . && rm -rf _ci
+      #     echo "## Source: ${{ inputs.mpas-repository }}@${{ inputs.mpas-ref }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build MPAS-A (double precision, OpenACC)
         uses: ./.github/actions/build-mpas

--- a/.github/workflows/test-cross-repo.yml
+++ b/.github/workflows/test-cross-repo.yml
@@ -45,7 +45,7 @@ jobs:
           REF="${{ inputs.mpas-ref || 'develop' }}"
           MPI="${{ inputs.mpi || 'mpich' }}"
 
-          echo "compilers=$(echo "[\"${COMPILERS:-gcc}\"]" | sed 's/,/","/g')" >> "$GITHUB_OUTPUT"
+          echo "compilers=$(printf '%s' "${COMPILERS:-gcc}" | jq -Rc 'split(",") | map(gsub("^\\s+|\\s+$";""))')" >> "$GITHUB_OUTPUT"
           echo "mpi=${MPI}" >> "$GITHUB_OUTPUT"
           echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
           echo "ref=${REF}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-cross-repo.yml
+++ b/.github/workflows/test-cross-repo.yml
@@ -1,0 +1,80 @@
+# Cross-repo testing: run CI against an external MPAS source repo.
+# Dispatch-only — does not affect badge status on master.
+
+name: "Cross-Repo Test"
+
+on:
+  workflow_dispatch:
+    inputs:
+      mpas-repository:
+        description: 'MPAS source repo (e.g. MPAS-Dev/MPAS-Model)'
+        required: true
+      mpas-ref:
+        description: 'Git ref (branch, tag, or SHA)'
+        required: true
+      compilers:
+        description: 'Compilers to test (comma-separated: gcc,nvhpc,oneapi)'
+        required: false
+        default: 'gcc,nvhpc,oneapi'
+      mpi:
+        description: 'MPI implementation'
+        required: false
+        default: 'mpich'
+      # GPU cross-repo testing disabled until NCAR security review of running
+      # external code on self-hosted CIRRUS runners is complete.
+      # include-gpu:
+      #   description: 'Include GPU (CUDA) test'
+      #   required: false
+      #   type: boolean
+      #   default: false
+
+jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      compilers: ${{ steps.set.outputs.compilers }}
+      mpi: ${{ steps.set.outputs.mpi }}
+      repo: ${{ steps.set.outputs.repo }}
+      ref: ${{ steps.set.outputs.ref }}
+    steps:
+      - id: set
+        shell: bash
+        run: |
+          COMPILERS="${{ inputs.compilers }}"
+          REPO="${{ inputs.mpas-repository || 'MPAS-Dev/MPAS-Model' }}"
+          REF="${{ inputs.mpas-ref || 'develop' }}"
+          MPI="${{ inputs.mpi || 'mpich' }}"
+
+          echo "compilers=$(echo "[\"${COMPILERS:-gcc}\"]" | sed 's/,/","/g')" >> "$GITHUB_OUTPUT"
+          echo "mpi=${MPI}" >> "$GITHUB_OUTPUT"
+          echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+
+          echo "## Cross-Repo Test" >> "$GITHUB_STEP_SUMMARY"
+          echo "| | |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Source** | [\`${REPO}@${REF}\`](https://github.com/${REPO}/tree/${REF}) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Compilers** | \`${COMPILERS:-gcc}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **MPI** | \`${MPI}\` |" >> "$GITHUB_STEP_SUMMARY"
+  cpu-matrix:
+    needs: config
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: ${{ fromJSON(needs.config.outputs.compilers) }}
+    uses: ./.github/workflows/_test-compiler.yml
+    with:
+      compiler: ${{ matrix.compiler }}
+      mpi: ${{ needs.config.outputs.mpi }}
+      mpas-repository: ${{ needs.config.outputs.repo }}
+      mpas-ref: ${{ needs.config.outputs.ref }}
+
+  # GPU cross-repo testing disabled until NCAR security review is complete.
+  # gpu:
+  #   needs: config
+  #   if: ${{ inputs.include-gpu }}
+  #   uses: ./.github/workflows/_test-gpu.yml
+  #   with:
+  #     mpi: ${{ needs.config.outputs.mpi }}
+  #     mpas-repository: ${{ needs.config.outputs.repo }}
+  #     mpas-ref: ${{ needs.config.outputs.ref }}


### PR DESCRIPTION
## Summary

- Add `mpas-repository` and `mpas-ref` workflow_dispatch inputs to `_test-compiler.yml` for building/testing MPAS source from external repos (e.g. `MPAS-Dev/MPAS-Model`)
- Add `test-cross-repo.yml` standalone caller with configurable compiler and MPI matrix
- GPU cross-repo testing (`_test-gpu.yml`) is commented out pending NCAR security review of running external code on self-hosted CIRRUS runners

## Test plan

- [ ] Trigger `Cross-Repo Test` with `MPAS-Dev/MPAS-Model` / `develop` to validate the two-step checkout and ECT
- [ ] Verify existing CPU subset workflows (e.g. `GNU+MPICH`) are unaffected (no-op when mpas-repository is empty)
- [ ] Verify GPU workflows still work without cross-repo inputs