### PR TITLE
Add bit-for-bit (BFB) CI workflows and README badges

### DIFF
--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -113,7 +113,24 @@ Key settings:
 - `RELEASE_ECT` — release tag for ECT data (summary + restart), pinned to MPAS-Dev version
 - `ECT_*` — ECT resolution, perturbation, summary/restart filenames, excluded-vars path, etc.
 - `PYCECT_TAG` — PyCECT git tag for `validate-ect`
-- `BFB_*` — bit-for-bit tests (`feature-ci-bfb`, workflows `bfb-io.yml`, `bfb-decomp.yml`, `_test-bfb.yml`)
+- `BFB_*` — default resolution, duration, and run timeout for bit-for-bit workflows; per-variant overrides live in the `variants` JSON passed to `_test-bfb.yml`
+
+### Bit-for-bit (`_test-bfb.yml`)
+
+The reusable workflow `_test-bfb.yml` takes a **`variants`** input: a JSON **array** of at least two objects. Each object describes one model run:
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `id` | yes | Unique slug (letters, digits, `.`, `_`, `-`); used for artifacts and working directories |
+| `ranks` | yes | MPI process count for that run |
+| `use_pio` | no | If true, build/link PIO for that variant’s build profile (default false = SMIOL) |
+| `label` | no | Short description for logs and the compare summary (defaults to `id`) |
+| `resolution` | no | Test case resolution for that run only (defaults to workflow `resolution` / `BFB_RESOLUTION`) |
+| `run_duration` | no | `config_run_duration` for that run only (defaults to workflow `run-duration` / `BFB_RUN_DURATION`) |
+
+Variants that share the same `use_pio` value reuse one compiled executable. The variant at **`reference_index`** (default **0**) is the reference; every other variant’s history file is compared to it (variable data, not raw file bytes — see `.github/scripts/compare-bfb-nc.py`).
+
+**Adding a new BFB test:** copy `bfb-io.yml` or `bfb-decomp.yml`, set `name` and `on`, and edit **`variants`**. MPI rank count and PIO vs SMIOL are common examples only; any future per-run knob exposed on `variants` and implemented in `_test-bfb.yml` / composite actions can be combined the same way.
 
 ## Container Environment
 

--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -113,7 +113,7 @@ Key settings:
 - `RELEASE_ECT` — release tag for ECT data (summary + restart), pinned to MPAS-Dev version
 - `ECT_*` — ECT resolution, perturbation, summary/restart filenames, excluded-vars path, etc.
 - `PYCECT_TAG` — PyCECT git tag for `validate-ect`
-- `BFB_*` — bit-for-bit test stub (reserved for `feature-ci-bfb-tests`)
+- `BFB_*` — bit-for-bit tests (`feature-ci-bfb`, workflows `bfb-io.yml`, `bfb-decomp.yml`, `_test-bfb.yml`)
 
 ## Container Environment
 

--- a/.github/ci-config.env
+++ b/.github/ci-config.env
@@ -110,7 +110,7 @@ PYCECT_TAG=3.3.1
 
 
 # ── BFB test configuration ───────────────────────
-# Stub for feature-ci-bfb-tests branch.
+# Used by BFB workflows (feature-ci-bfb branch, _test-bfb.yml).
 # Bit-for-bit reproducibility tests using the 240km single-precision
 # test case with 3 timesteps (config_dt=1200s).
 

--- a/.github/scripts/compare-bfb-nc.py
+++ b/.github/scripts/compare-bfb-nc.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Compare two NetCDF files for bitwise-identical variable *data*.
+
+NetCDF files from PIO vs SMIOL or different MPI layouts often differ in headers,
+attributes, or chunking while variable arrays remain identical — `cmp` is too strict.
+"""
+from __future__ import annotations
+
+import sys
+
+import netCDF4 as nc
+import numpy as np
+
+
+def as_array(x):
+    if np.ma.isMaskedArray(x):
+        return np.ma.filled(x)
+    return np.asarray(x)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: compare-bfb-nc.py <reference.nc> <candidate.nc>", file=sys.stderr)
+        return 2
+    path_ref, path_test = sys.argv[1], sys.argv[2]
+    diffs: list[str] = []
+    with nc.Dataset(path_ref) as ds_ref, nc.Dataset(path_test) as ds_test:
+        vr = set(ds_ref.variables)
+        vt = set(ds_test.variables)
+        if vr != vt:
+            only_r = sorted(vr - vt)
+            only_t = sorted(vt - vr)
+            print(
+                "FAIL\t"
+                f"variable set mismatch: only in reference {only_r}, only in candidate {only_t}"
+            )
+            return 1
+        for name in sorted(vr):
+            a = as_array(ds_ref.variables[name][:])
+            b = as_array(ds_test.variables[name][:])
+            if a.shape != b.shape:
+                diffs.append(f"{name}: shape {a.shape} vs {b.shape}")
+                continue
+            if not np.array_equal(a, b):
+                if np.issubdtype(a.dtype, np.floating) or np.issubdtype(
+                    a.dtype, np.complexfloating
+                ):
+                    maxdiff = float(np.max(np.abs(a - b)))
+                    diffs.append(f"{name} (max|diff|={maxdiff:.6e})")
+                else:
+                    diffs.append(f"{name} (data differs)")
+    if diffs:
+        msg = "; ".join(diffs[:25])
+        print(f"FAIL\t{msg}")
+        if len(diffs) > 25:
+            print(f"... and {len(diffs) - 25} more", file=sys.stderr)
+        return 1
+    print("OK\tall variables bitwise-identical (NetCDF container/metadata may differ)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/_test-bfb.yml
+++ b/.github/workflows/_test-bfb.yml
@@ -214,41 +214,28 @@ jobs:
               return
             fi
 
+            # NetCDF byte-for-byte identity (optional fast path).
             if cmp -s "${ref_file}" "${test_file}"; then
-              echo "${label}: IDENTICAL"
-              echo "- **${label}**: :white_check_mark: identical" >> "$GITHUB_STEP_SUMMARY"
+              echo "${label}: byte-identical"
+              echo "- **${label}**: :white_check_mark: byte-identical" >> "$GITHUB_STEP_SUMMARY"
+              PASS=$((PASS + 1))
+              return
+            fi
+
+            # PIO vs SMIOL and different rank counts often change file metadata / encoding
+            # while history variables remain bitwise identical — compare data only.
+            RESULT=$(python3 "${GITHUB_WORKSPACE}/.github/scripts/compare-bfb-nc.py" "${ref_file}" "${test_file}")
+            STATUS=$?
+            IFS=$'\t' read -r CODE DETAIL <<< "${RESULT}"
+
+            if [ "${STATUS}" -eq 0 ] && [ "${CODE}" = "OK" ]; then
+              echo "${label}: data-identical (${DETAIL})"
+              echo "- **${label}**: :white_check_mark: data-identical (${DETAIL})" >> "$GITHUB_STEP_SUMMARY"
               PASS=$((PASS + 1))
             else
-              echo "${label}: DIFFER"
+              echo "${label}: DIFFER — ${DETAIL}"
               FAIL=$((FAIL + 1))
-
-              DIFF_DETAIL=$(python3 - "${ref_file}" "${test_file}" <<'PYEOF'
-          import netCDF4 as nc, numpy as np, sys
-          ds_ref = nc.Dataset(sys.argv[1])
-          ds_test = nc.Dataset(sys.argv[2])
-          diffs = []
-          for var in ds_ref.variables:
-              if var in ds_test.variables:
-                  try:
-                      ref_data = ds_ref.variables[var][:]
-                      test_data = ds_test.variables[var][:]
-                      if not np.array_equal(ref_data, test_data):
-                          maxdiff = float(np.max(np.abs(ref_data - test_data)))
-                          diffs.append(f"{var} (max|diff|={maxdiff:.6e})")
-                  except Exception:
-                      pass
-          ds_ref.close()
-          ds_test.close()
-          if diffs:
-              print(", ".join(diffs[:10]))
-              if len(diffs) > 10:
-                  print(f"  ... and {len(diffs) - 10} more variables")
-          else:
-              print("files differ but no variable-level differences found (possible metadata change)")
-          PYEOF
-              )
-              echo "  Differing variables: ${DIFF_DETAIL}"
-              ERRORS="${ERRORS}\n- **${label}**: :x: differs — ${DIFF_DETAIL}"
+              ERRORS="${ERRORS}\n- **${label}**: :x: ${DETAIL}"
             fi
           }
 
@@ -276,7 +263,7 @@ jobs:
             echo "::error::BFB comparison failed: ${FAIL} of ${TOTAL} comparisons differ"
             exit 1
           fi
-          echo "All ${TOTAL} comparisons are bit-for-bit identical"
+          echo "All ${TOTAL} comparisons passed (byte-identical files or bitwise-identical variable data)"
 
   cleanup:
     needs: [run, compare]

--- a/.github/workflows/_test-bfb.yml
+++ b/.github/workflows/_test-bfb.yml
@@ -1,0 +1,296 @@
+# Reusable workflow: bit-for-bit reproducibility tests.
+#
+# Verifies that MPAS-A output is byte-identical across configurable
+# combinations of I/O libraries (SMIOL, PIO) and MPI decompositions.
+# The first io-lib at the first rank-count is used as the reference;
+# every other combination must match exactly.
+
+name: _test-bfb
+
+permissions:
+  contents: read
+  actions: write
+
+on:
+  workflow_call:
+    inputs:
+      compiler:
+        description: 'Compiler family (gcc, nvhpc, oneapi)'
+        required: true
+        type: string
+      mpi:
+        description: 'MPI implementation (mpich, openmpi)'
+        required: true
+        type: string
+      resolution:
+        description: 'Test case resolution'
+        required: false
+        type: string
+        default: '240km'
+      precision:
+        description: 'Floating-point precision (single or double)'
+        required: false
+        type: string
+        default: 'single'
+      io-libs:
+        description: 'Comma-separated I/O libraries to test (smiol, pio)'
+        required: false
+        type: string
+        default: 'smiol,pio'
+      rank-counts:
+        description: 'Comma-separated MPI rank counts to test'
+        required: false
+        type: string
+        default: '1,4'
+      run-duration:
+        description: 'Model run duration (D_HH:MM:SS). Default matches BFB_* in ci-config.env (240km).'
+        required: false
+        type: string
+        default: '0_01:00:00'
+      run-timeout:
+        description: 'Run step timeout in minutes'
+        required: false
+        type: string
+        default: '10'
+
+jobs:
+  config:
+    name: Resolve Config
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.container.outputs.image }}
+      io: ${{ steps.matrix.outputs.io }}
+      ranks: ${{ steps.matrix.outputs.ranks }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github
+
+      - uses: ./.github/actions/resolve-container
+        id: container
+        with:
+          compiler: ${{ inputs.compiler }}
+          mpi: ${{ inputs.mpi }}
+
+      - name: Build matrices
+        id: matrix
+        shell: bash
+        run: |
+          IO_JSON=$(jq -nc --arg s '${{ inputs.io-libs }}' '($s | split(",") | map(gsub("^\\s+|\\s+$";"")))')
+          RANKS_JSON=$(jq -nc --arg s '${{ inputs.rank-counts }}' '($s | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(tonumber))')
+          echo "io=${IO_JSON}" >> "$GITHUB_OUTPUT"
+          echo "ranks=${RANKS_JSON}" >> "$GITHUB_OUTPUT"
+          echo "IO matrix:    ${IO_JSON}"
+          echo "Ranks matrix: ${RANKS_JSON}"
+
+  build:
+    needs: config
+    strategy:
+      fail-fast: true
+      matrix:
+        io: ${{ fromJSON(needs.config.outputs.io) }}
+    name: Build (${{ matrix.io }})
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.config.outputs.image }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: 'true'
+
+      - name: Build MPAS-A
+        uses: ./.github/actions/build-mpas
+        with:
+          compiler: ${{ inputs.compiler }}
+          use-pio: ${{ matrix.io == 'pio' && 'true' || 'false' }}
+          precision: ${{ inputs.precision }}
+
+      - name: Upload executable
+        uses: actions/upload-artifact@v6
+        with:
+          name: exe-bfb-${{ matrix.io }}
+          path: atmosphere_model
+          retention-days: 1
+
+  run:
+    needs: [config, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        io: ${{ fromJSON(needs.config.outputs.io) }}
+        ranks: ${{ fromJSON(needs.config.outputs.ranks) }}
+    name: Run (${{ matrix.io }}, ${{ matrix.ranks }} ranks)
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.config.outputs.image }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download executable
+        uses: actions/download-artifact@v7
+        with:
+          name: exe-bfb-${{ matrix.io }}
+
+      - name: Run MPAS-A
+        uses: ./.github/actions/run-mpas
+        with:
+          executable: ./atmosphere_model
+          num-procs: '${{ matrix.ranks }}'
+          resolution: ${{ inputs.resolution }}
+          run-duration: ${{ inputs.run-duration }}
+          run-timeout: ${{ inputs.run-timeout }}
+          mpi-impl: ${{ inputs.mpi }}
+          working-dir: run-${{ matrix.io }}-${{ matrix.ranks }}
+          strict-exit-check: 'false'
+
+      - name: Upload history output
+        uses: actions/upload-artifact@v6
+        with:
+          name: bfb-history-${{ matrix.io }}-${{ matrix.ranks }}
+          path: run-${{ matrix.io }}-${{ matrix.ranks }}/history.*.nc
+          retention-days: 1
+
+  compare:
+    needs: [config, run]
+    if: ${{ !cancelled() && needs.run.result == 'success' }}
+    name: Compare BFB
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github
+
+      - name: Download all history files
+        uses: actions/download-artifact@v7
+        with:
+          pattern: bfb-history-*
+          path: bfb-results
+          merge-multiple: false
+
+      - name: Compare outputs
+        env:
+          IO_LIBS: ${{ inputs.io-libs }}
+          RANK_COUNTS: ${{ inputs.rank-counts }}
+        shell: bash
+        run: |
+          pip install --quiet netCDF4 numpy
+
+          IFS=',' read -ra IO_ARR <<< "${IO_LIBS}"
+          IFS=',' read -ra RANK_ARR <<< "${RANK_COUNTS}"
+          for i in "${!IO_ARR[@]}"; do IO_ARR[$i]=$(echo "${IO_ARR[$i]}" | tr -d '[:space:]'); done
+          for i in "${!RANK_ARR[@]}"; do RANK_ARR[$i]=$(echo "${RANK_ARR[$i]}" | tr -d '[:space:]'); done
+
+          REF_IO="${IO_ARR[0]}"
+          REF_RANKS="${RANK_ARR[0]}"
+
+          echo "## Bit-for-Bit Comparison" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          PASS=0
+          FAIL=0
+          ERRORS=""
+
+          REF_DIR="bfb-results/bfb-history-${REF_IO}-${REF_RANKS}"
+          REF_FILE=$(ls ${REF_DIR}/history.*.nc 2>/dev/null | head -1)
+          if [ -z "${REF_FILE}" ]; then
+            echo "::error::Reference history file not found in ${REF_DIR}"
+            echo "Available artifacts:"
+            find bfb-results -name '*.nc' -type f
+            exit 1
+          fi
+          echo "Reference: ${REF_FILE} (${REF_IO} / ${REF_RANKS} rank(s))"
+          echo "Reference: \`${REF_IO} / ${REF_RANKS} rank(s)\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          compare_files() {
+            local label="$1"
+            local test_file="$2"
+            local ref_file="$3"
+
+            if [ ! -f "${test_file}" ]; then
+              echo "::error::${label}: history file missing"
+              ERRORS="${ERRORS}\n- **${label}**: :x: history file missing"
+              FAIL=$((FAIL + 1))
+              return
+            fi
+
+            if cmp -s "${ref_file}" "${test_file}"; then
+              echo "${label}: IDENTICAL"
+              echo "- **${label}**: :white_check_mark: identical" >> "$GITHUB_STEP_SUMMARY"
+              PASS=$((PASS + 1))
+            else
+              echo "${label}: DIFFER"
+              FAIL=$((FAIL + 1))
+
+              DIFF_DETAIL=$(python3 - "${ref_file}" "${test_file}" <<'PYEOF'
+          import netCDF4 as nc, numpy as np, sys
+          ds_ref = nc.Dataset(sys.argv[1])
+          ds_test = nc.Dataset(sys.argv[2])
+          diffs = []
+          for var in ds_ref.variables:
+              if var in ds_test.variables:
+                  try:
+                      ref_data = ds_ref.variables[var][:]
+                      test_data = ds_test.variables[var][:]
+                      if not np.array_equal(ref_data, test_data):
+                          maxdiff = float(np.max(np.abs(ref_data - test_data)))
+                          diffs.append(f"{var} (max|diff|={maxdiff:.6e})")
+                  except Exception:
+                      pass
+          ds_ref.close()
+          ds_test.close()
+          if diffs:
+              print(", ".join(diffs[:10]))
+              if len(diffs) > 10:
+                  print(f"  ... and {len(diffs) - 10} more variables")
+          else:
+              print("files differ but no variable-level differences found (possible metadata change)")
+          PYEOF
+              )
+              echo "  Differing variables: ${DIFF_DETAIL}"
+              ERRORS="${ERRORS}\n- **${label}**: :x: differs — ${DIFF_DETAIL}"
+            fi
+          }
+
+          for io in "${IO_ARR[@]}"; do
+            for ranks in "${RANK_ARR[@]}"; do
+              if [ "${io}" = "${REF_IO}" ] && [ "${ranks}" = "${REF_RANKS}" ]; then
+                continue
+              fi
+              DIR="bfb-results/bfb-history-${io}-${ranks}"
+              TEST_FILE=$(ls ${DIR}/history.*.nc 2>/dev/null | head -1)
+              compare_files "${io} / ${ranks} rank(s)" "${TEST_FILE}" "${REF_FILE}"
+            done
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${ERRORS}" ]; then
+            echo -e "${ERRORS}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          TOTAL=$((PASS + FAIL))
+          echo "**Result: ${PASS}/${TOTAL} comparisons identical**" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ ${FAIL} -gt 0 ]; then
+            echo "::error::BFB comparison failed: ${FAIL} of ${TOTAL} comparisons differ"
+            exit 1
+          fi
+          echo "All ${TOTAL} comparisons are bit-for-bit identical"
+
+  cleanup:
+    needs: [run, compare]
+    if: always()
+    runs-on: ubuntu-latest
+    name: Cleanup
+    steps:
+      - name: Delete temporary artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+            --paginate --jq '.artifacts[] | select(.name | startswith("exe-bfb-") or startswith("bfb-history-")) | .id' \
+          | while read id; do
+              gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id || true
+            done || true

--- a/.github/workflows/_test-bfb.yml
+++ b/.github/workflows/_test-bfb.yml
@@ -1,9 +1,11 @@
 # Reusable workflow: bit-for-bit reproducibility tests.
 #
-# Verifies that MPAS-A output is byte-identical across configurable
-# combinations of I/O libraries (SMIOL, PIO) and MPI decompositions.
-# The first io-lib at the first rank-count is used as the reference;
-# every other combination must match exactly.
+# Callers pass a JSON array of *variants*: independent run configurations that must
+# produce bitwise-identical history variable data. The first variant (or
+# reference_index) is the reference; every other variant is compared against it.
+#
+# MPI rank count and PIO vs SMIOL are common dimensions but not special — add any
+# new scenario by appending another variant object (and a small caller workflow).
 
 name: _test-bfb
 
@@ -15,35 +17,32 @@ on:
   workflow_call:
     inputs:
       compiler:
-        description: 'Compiler family (gcc, nvhpc, oneapi)'
+        description: 'Compiler family for the container image (gcc, nvhpc, oneapi)'
         required: true
         type: string
       mpi:
-        description: 'MPI implementation (mpich, openmpi)'
+        description: 'MPI implementation for the container image (mpich, openmpi)'
+        required: true
+        type: string
+      variants:
+        description: >
+          JSON array of at least two variant objects. Required per variant: id (unique slug),
+          ranks (MPI processes). Optional: use_pio (default false), label (summary text),
+          resolution, run_duration (override workflow defaults for that variant only).
         required: true
         type: string
       resolution:
-        description: 'Test case resolution'
+        description: 'Default test case resolution when a variant omits resolution'
         required: false
         type: string
         default: '240km'
       precision:
-        description: 'Floating-point precision (single or double)'
+        description: 'Floating-point precision for all builds (single or double)'
         required: false
         type: string
         default: 'single'
-      io-libs:
-        description: 'Comma-separated I/O libraries to test (smiol, pio)'
-        required: false
-        type: string
-        default: 'smiol,pio'
-      rank-counts:
-        description: 'Comma-separated MPI rank counts to test'
-        required: false
-        type: string
-        default: '1,4'
       run-duration:
-        description: 'Model run duration (D_HH:MM:SS). Default matches BFB_* in ci-config.env (240km).'
+        description: 'Default model run duration (D_HH:MM:SS) when a variant omits run_duration'
         required: false
         type: string
         default: '0_01:00:00'
@@ -52,6 +51,11 @@ on:
         required: false
         type: string
         default: '10'
+      reference_index:
+        description: 'Which variant (0-based) is the reference for comparison'
+        required: false
+        type: number
+        default: 0
 
 jobs:
   config:
@@ -59,8 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.container.outputs.image }}
-      io: ${{ steps.matrix.outputs.io }}
-      ranks: ${{ steps.matrix.outputs.ranks }}
+      build_tags: ${{ steps.variants.outputs.build_tags }}
+      run_variants: ${{ steps.variants.outputs.run_variants }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -72,24 +76,55 @@ jobs:
           compiler: ${{ inputs.compiler }}
           mpi: ${{ inputs.mpi }}
 
-      - name: Build matrices
-        id: matrix
+      - name: Parse variants
+        id: variants
         shell: bash
+        env:
+          VARIANTS_JSON: ${{ inputs.variants }}
+          DEF_RES: ${{ inputs.resolution }}
+          DEF_DUR: ${{ inputs.run-duration }}
+          REF_IDX: ${{ inputs.reference_index }}
         run: |
-          IO_JSON=$(jq -nc --arg s '${{ inputs.io-libs }}' '($s | split(",") | map(gsub("^\\s+|\\s+$";"")))')
-          RANKS_JSON=$(jq -nc --arg s '${{ inputs.rank-counts }}' '($s | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(tonumber))')
-          echo "io=${IO_JSON}" >> "$GITHUB_OUTPUT"
-          echo "ranks=${RANKS_JSON}" >> "$GITHUB_OUTPUT"
-          echo "IO matrix:    ${IO_JSON}"
-          echo "Ranks matrix: ${RANKS_JSON}"
+          set -euo pipefail
+          RI="${REF_IDX:-0}"
+          echo "${VARIANTS_JSON}" | jq -e 'type == "array" and length >= 2' >/dev/null \
+            || { echo "::error::variants must be a JSON array with at least two entries"; exit 1; }
+          echo "${VARIANTS_JSON}" | jq -e 'all(.[]; has("id") and has("ranks"))' >/dev/null \
+            || { echo "::error::each variant must include id and ranks"; exit 1; }
+          echo "${VARIANTS_JSON}" | jq -e 'all(.[]; .id | test("^[a-zA-Z0-9._-]+$"))' >/dev/null \
+            || { echo "::error::variant id must match ^[a-zA-Z0-9._-]+$"; exit 1; }
+          N=$(echo "${VARIANTS_JSON}" | jq 'length')
+          if [ "${RI}" -lt 0 ] || [ "${RI}" -ge "${N}" ]; then
+            echo "::error::reference_index must be between 0 and $((N - 1))"
+            exit 1
+          fi
+
+          BUILD_TAGS=$(echo "${VARIANTS_JSON}" | jq -c \
+            '[.[] | (if (.use_pio // false) then "pio" else "smiol" end)] | unique')
+          RUN_VARIANTS=$(echo "${VARIANTS_JSON}" | jq -c \
+            --arg defres "${DEF_RES}" \
+            --arg defdur "${DEF_DUR}" \
+            '[.[] | {
+              id,
+              build_tag: (if (.use_pio // false) then "pio" else "smiol" end),
+              ranks: (.ranks | tonumber),
+              resolution: (.resolution // $defres),
+              run_duration: (.run_duration // $defdur),
+              label: (.label // .id)
+            }]')
+
+          echo "build_tags=${BUILD_TAGS}" >> "$GITHUB_OUTPUT"
+          echo "run_variants=${RUN_VARIANTS}" >> "$GITHUB_OUTPUT"
+          echo "Build matrix (unique I/O builds): ${BUILD_TAGS}"
+          echo "Run matrix: ${RUN_VARIANTS}"
 
   build:
     needs: config
     strategy:
       fail-fast: true
       matrix:
-        io: ${{ fromJSON(needs.config.outputs.io) }}
-    name: Build (${{ matrix.io }})
+        build_tag: ${{ fromJSON(needs.config.outputs.build_tags) }}
+    name: Build (${{ matrix.build_tag }})
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.config.outputs.image }}
@@ -102,13 +137,13 @@ jobs:
         uses: ./.github/actions/build-mpas
         with:
           compiler: ${{ inputs.compiler }}
-          use-pio: ${{ matrix.io == 'pio' && 'true' || 'false' }}
+          use-pio: ${{ matrix.build_tag == 'pio' && 'true' || 'false' }}
           precision: ${{ inputs.precision }}
 
       - name: Upload executable
         uses: actions/upload-artifact@v6
         with:
-          name: exe-bfb-${{ matrix.io }}
+          name: exe-bfb-${{ matrix.build_tag }}
           path: atmosphere_model
           retention-days: 1
 
@@ -117,9 +152,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        io: ${{ fromJSON(needs.config.outputs.io) }}
-        ranks: ${{ fromJSON(needs.config.outputs.ranks) }}
-    name: Run (${{ matrix.io }}, ${{ matrix.ranks }} ranks)
+        include: ${{ fromJSON(needs.config.outputs.run_variants) }}
+    name: Run (${{ matrix.id }})
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.config.outputs.image }}
@@ -129,25 +163,25 @@ jobs:
       - name: Download executable
         uses: actions/download-artifact@v7
         with:
-          name: exe-bfb-${{ matrix.io }}
+          name: exe-bfb-${{ matrix.build_tag }}
 
       - name: Run MPAS-A
         uses: ./.github/actions/run-mpas
         with:
           executable: ./atmosphere_model
           num-procs: '${{ matrix.ranks }}'
-          resolution: ${{ inputs.resolution }}
-          run-duration: ${{ inputs.run-duration }}
+          resolution: ${{ matrix.resolution }}
+          run-duration: ${{ matrix.run_duration }}
           run-timeout: ${{ inputs.run-timeout }}
           mpi-impl: ${{ inputs.mpi }}
-          working-dir: run-${{ matrix.io }}-${{ matrix.ranks }}
+          working-dir: run-${{ matrix.id }}
           strict-exit-check: 'false'
 
       - name: Upload history output
         uses: actions/upload-artifact@v6
         with:
-          name: bfb-history-${{ matrix.io }}-${{ matrix.ranks }}
-          path: run-${{ matrix.io }}-${{ matrix.ranks }}/history.*.nc
+          name: bfb-history-${{ matrix.id }}
+          path: run-${{ matrix.id }}/history.*.nc
           retention-days: 1
 
   compare:
@@ -169,38 +203,46 @@ jobs:
 
       - name: Compare outputs
         env:
-          IO_LIBS: ${{ inputs.io-libs }}
-          RANK_COUNTS: ${{ inputs.rank-counts }}
+          VARIANTS_JSON: ${{ inputs.variants }}
+          REFERENCE_INDEX: ${{ inputs.reference_index }}
         shell: bash
         run: |
           pip install --quiet netCDF4 numpy
 
-          IFS=',' read -ra IO_ARR <<< "${IO_LIBS}"
-          IFS=',' read -ra RANK_ARR <<< "${RANK_COUNTS}"
-          for i in "${!IO_ARR[@]}"; do IO_ARR[$i]=$(echo "${IO_ARR[$i]}" | tr -d '[:space:]'); done
-          for i in "${!RANK_ARR[@]}"; do RANK_ARR[$i]=$(echo "${RANK_ARR[$i]}" | tr -d '[:space:]'); done
+          RI="${REFERENCE_INDEX:-0}"
 
-          REF_IO="${IO_ARR[0]}"
-          REF_RANKS="${RANK_ARR[0]}"
+          MERGED=$(echo "${VARIANTS_JSON}" | jq -c \
+            --arg defres "${{ inputs.resolution }}" \
+            --arg defdur "${{ inputs.run-duration }}" \
+            '[.[] | {
+              id,
+              build_tag: (if (.use_pio // false) then "pio" else "smiol" end),
+              ranks: (.ranks | tonumber),
+              resolution: (.resolution // $defres),
+              run_duration: (.run_duration // $defdur),
+              label: (.label // .id)
+            }]')
+
+          REF_ID=$(echo "${MERGED}" | jq -r --argjson idx "${RI}" '.[$idx].id')
+          REF_LABEL=$(echo "${MERGED}" | jq -r --argjson idx "${RI}" '.[$idx].label')
 
           echo "## Bit-for-Bit Comparison" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Reference variant: **${REF_LABEL}** (\`${REF_ID}\`)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           PASS=0
           FAIL=0
           ERRORS=""
 
-          REF_DIR="bfb-results/bfb-history-${REF_IO}-${REF_RANKS}"
+          REF_DIR="bfb-results/bfb-history-${REF_ID}"
           REF_FILE=$(ls ${REF_DIR}/history.*.nc 2>/dev/null | head -1)
           if [ -z "${REF_FILE}" ]; then
             echo "::error::Reference history file not found in ${REF_DIR}"
-            echo "Available artifacts:"
             find bfb-results -name '*.nc' -type f
             exit 1
           fi
-          echo "Reference: ${REF_FILE} (${REF_IO} / ${REF_RANKS} rank(s))"
-          echo "Reference: \`${REF_IO} / ${REF_RANKS} rank(s)\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Reference file: ${REF_FILE}"
 
           compare_files() {
             local label="$1"
@@ -214,7 +256,6 @@ jobs:
               return
             fi
 
-            # NetCDF byte-for-byte identity (optional fast path).
             if cmp -s "${ref_file}" "${test_file}"; then
               echo "${label}: byte-identical"
               echo "- **${label}**: :white_check_mark: byte-identical" >> "$GITHUB_STEP_SUMMARY"
@@ -222,8 +263,6 @@ jobs:
               return
             fi
 
-            # PIO vs SMIOL and different rank counts often change file metadata / encoding
-            # while history variables remain bitwise identical — compare data only.
             RESULT=$(python3 "${GITHUB_WORKSPACE}/.github/scripts/compare-bfb-nc.py" "${ref_file}" "${test_file}")
             STATUS=$?
             IFS=$'\t' read -r CODE DETAIL <<< "${RESULT}"
@@ -239,15 +278,16 @@ jobs:
             fi
           }
 
-          for io in "${IO_ARR[@]}"; do
-            for ranks in "${RANK_ARR[@]}"; do
-              if [ "${io}" = "${REF_IO}" ] && [ "${ranks}" = "${REF_RANKS}" ]; then
-                continue
-              fi
-              DIR="bfb-results/bfb-history-${io}-${ranks}"
-              TEST_FILE=$(ls ${DIR}/history.*.nc 2>/dev/null | head -1)
-              compare_files "${io} / ${ranks} rank(s)" "${TEST_FILE}" "${REF_FILE}"
-            done
+          N=$(echo "${MERGED}" | jq 'length')
+          for ((i = 0; i < N; i++)); do
+            VID=$(echo "${MERGED}" | jq -r --argjson idx "$i" '.[$idx].id')
+            if [ "${VID}" = "${REF_ID}" ]; then
+              continue
+            fi
+            VLABEL=$(echo "${MERGED}" | jq -r --argjson idx "$i" '.[$idx].label')
+            DIR="bfb-results/bfb-history-${VID}"
+            TEST_FILE=$(ls ${DIR}/history.*.nc 2>/dev/null | head -1)
+            compare_files "${VLABEL} (\`${VID}\`)" "${TEST_FILE}" "${REF_FILE}"
           done
 
           echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bfb-decomp.yml
+++ b/.github/workflows/bfb-decomp.yml
@@ -1,0 +1,18 @@
+# Bit-for-bit: MPI decomposition (1 vs 4 ranks), SMIOL only.
+# Uses reusable _test-bfb; reference = 1 rank vs 4 ranks.
+
+name: "BFB: Decomposition (1 vs 4 ranks)"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [feature-ci-bfb]
+
+jobs:
+  test:
+    uses: ./.github/workflows/_test-bfb.yml
+    with:
+      compiler: gcc
+      mpi: mpich
+      io-libs: 'smiol'
+      rank-counts: '1,4'

--- a/.github/workflows/bfb-decomp.yml
+++ b/.github/workflows/bfb-decomp.yml
@@ -1,5 +1,5 @@
-# Bit-for-bit: MPI decomposition (1 vs 4 ranks), SMIOL only.
-# Uses reusable _test-bfb; reference = 1 rank vs 4 ranks.
+# Example BFB caller: same I/O build, different MPI rank counts (decomposition).
+# Add new scenarios by copying this file and changing `variants` (see AGENT_GUIDE.md).
 
 name: "BFB: Decomposition (1 vs 4 ranks)"
 
@@ -14,5 +14,6 @@ jobs:
     with:
       compiler: gcc
       mpi: mpich
-      io-libs: 'smiol'
-      rank-counts: '1,4'
+      variants: >-
+        [{"id":"r1","ranks":1,"label":"1 rank"},
+         {"id":"r4","ranks":4,"label":"4 ranks"}]

--- a/.github/workflows/bfb-io.yml
+++ b/.github/workflows/bfb-io.yml
@@ -1,0 +1,18 @@
+# Bit-for-bit: SMIOL vs PIO (same MPI rank count).
+# Uses reusable _test-bfb; reference = first I/O lib (smiol) at 4 ranks vs PIO at 4 ranks.
+
+name: "BFB: I/O (SMIOL vs PIO)"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [feature-ci-bfb]
+
+jobs:
+  test:
+    uses: ./.github/workflows/_test-bfb.yml
+    with:
+      compiler: gcc
+      mpi: mpich
+      io-libs: 'smiol,pio'
+      rank-counts: '4'

--- a/.github/workflows/bfb-io.yml
+++ b/.github/workflows/bfb-io.yml
@@ -1,5 +1,5 @@
-# Bit-for-bit: SMIOL vs PIO (same MPI rank count).
-# Uses reusable _test-bfb; reference = first I/O lib (smiol) at 4 ranks vs PIO at 4 ranks.
+# Example BFB caller: two I/O builds (SMIOL vs PIO), same rank count.
+# Add new scenarios by copying this file and changing `variants` (see AGENT_GUIDE.md).
 
 name: "BFB: I/O (SMIOL vs PIO)"
 
@@ -14,5 +14,6 @@ jobs:
     with:
       compiler: gcc
       mpi: mpich
-      io-libs: 'smiol,pio'
-      rank-counts: '4'
+      variants: >-
+        [{"id":"smiol-r4","ranks":4,"label":"SMIOL, 4 ranks"},
+         {"id":"pio-r4","use_pio":true,"ranks":4,"label":"PIO, 4 ranks"}]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ MPAS-v8.3.1
 
 ## CI Status
 
+### ECT (PyCECT)
+
 MPICH subsets run on every push and PR. OpenMPI and GPU subsets are available via manual dispatch.
 Each test builds in double precision, runs 3 perturbed ensemble members (4 MPI ranks), and validates with [PyCECT](https://github.com/NCAR/PyCECT).
 
@@ -16,13 +18,21 @@ Each test builds in double precision, runs 3 perturbed ensemble members (4 MPI r
 | NVHPC | OpenMPI | CPU | [![NVHPC+OpenMPI (CPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-nvhpc-openmpi.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-nvhpc-openmpi.yml) | `hpcdev:almalinux9-nvhpc-openmpi-26.02` |
 | NVHPC | MPICH | GPU | [![NVHPC+MPICH (GPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-mpich.yml) | `hpcdev:almalinux9-nvhpc-mpich-cuda-26.02` |
 | NVHPC | OpenMPI | GPU | [![NVHPC+OpenMPI (GPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-openmpi.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-openmpi.yml) | `hpcdev:almalinux9-nvhpc-openmpi-cuda-26.02` |
-| | | | | |
-| Coverage | | | [![Coverage](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/coverage.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/coverage.yml) [![codecov](https://codecov.io/gh/NCAR/MPAS-Model-CI/graph/badge.svg)](https://codecov.io/gh/NCAR/MPAS-Model-CI) | |
 
 \* Intel pinned to `hpcdev 25.09` (IFX 2025.2) to avoid an [IFX 2025.3 preprocessor regression](.github/ci-config.env).
 
-Container images are from [ncarcisl/hpcdev](https://hub.docker.com/r/ncarcisl/hpcdev-x86_64).
+ECT subset container images are from [ncarcisl/hpcdev](https://hub.docker.com/r/ncarcisl/hpcdev-x86_64).
 Image tags, compiler mappings, and MPI flags are configured in [`.github/ci-config.env`](.github/ci-config.env).
+
+### Bit-for-bit and coverage
+
+Bit-for-bit workflows compare history output in single precision (240km case; see `BFB_*` in [`.github/ci-config.env`](.github/ci-config.env)). They run on `workflow_dispatch` and on pushes to `feature-ci-bfb`.
+
+| Test | Status |
+|------|--------|
+| BFB: I/O (SMIOL vs PIO) | [![BFB: I/O (SMIOL vs PIO)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-io.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-io.yml) |
+| BFB: Decomposition (1 vs 4 ranks) | [![BFB: Decomposition (1 vs 4 ranks)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp.yml) |
+| Code coverage | [![Code Coverage](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/coverage.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/coverage.yml) [![codecov](https://codecov.io/gh/NCAR/MPAS-Model-CI/graph/badge.svg)](https://codecov.io/gh/NCAR/MPAS-Model-CI) |
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for
 developing atmosphere, ocean, and other earth-system simulation components for


### PR DESCRIPTION
## Summary

This pull request adds reusable bit-for-bit testing for MPAS-Atmosphere history output, two example callers (SMIOL vs PIO at 4 ranks; SMIOL 1 vs 4 ranks), NetCDF **data** comparison (metadata/encoding may differ), flexible **variants** JSON on the reusable workflow, and README tables that separate **ECT (PyCECT)** from **bit-for-bit and coverage**.

## Changes

- **\_test-bfb.yml\**: \workflow_call\ with a \ariants\ JSON array (\id\, \anks\, optional \use_pio\, \label\, \esolution\, \un_duration\, \eference_index\). Builds unique executables per PIO vs SMIOL profile; runs and compares history variables.
- **\fb-io.yml\ / \fb-decomp.yml\**: Example callers; \workflow_dispatch\ and push to \eature-ci-bfb\.
- **\.github/scripts/compare-bfb-nc.py\**: Per-variable bitwise comparison; \cmp\ kept as a fast path when files are byte-identical.
- **README.md**: ECT table vs BFB + coverage table; badges for BFB workflows.
- **AGENT_GUIDE.md**: Documents BFB \ariants\ and how to add new scenarios.

## Notes

Default run settings align with \BFB_*\ in \.github/ci-config.env\ (240km, single precision, duration, timeout).

Made with [Cursor](https://cursor.com)