### PR TITLE
NVHPC+MPICH+CUDA build check on GPU-less GitHub-hosted runners

### DIFF
--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -38,6 +38,7 @@ This is `NCAR/MPAS-Model-CI`, a fork of `MPAS-Dev/MPAS-Model`. The MPAS source c
     ├── test-nvhpc-openmpi.yml   # Caller: NVHPC+OpenMPI (dispatch-only)
     ├── test-gpu-mpich.yml       # Caller: NVHPC+MPICH GPU (dispatch-only)
     ├── test-gpu-openmpi.yml     # Caller: NVHPC+OpenMPI GPU (dispatch-only)
+    ├── compile-nvhpc-cuda-mpich.yml  # NVHPC+MPICH+CUDA compile-only (GA-hosted)
     ├── ect-test.yml             # Standalone ECT (debugging)
     ├── ect-ensemble-gen.yml     # Generate ensemble summary (manual, expensive)
     ├── coverage.yml             # GCC coverage + Codecov upload
@@ -76,7 +77,8 @@ Each compiler+MPI combination has a thin caller workflow that invokes a reusable
 - **GPU subsets** call `_test-gpu.yml` with `mpi` input (always NVHPC)
 
 **MPICH callers** (`test-gcc-mpich`, `test-intel-mpich`, `test-nvhpc-mpich`) run on push/PR to `master`/`develop`.
-**OpenMPI and GPU callers** are `workflow_dispatch` only.
+**compile-nvhpc-cuda-mpich** (NVHPC + OpenACC compile-only on GitHub-hosted runners) also runs on push/PR.
+**OpenMPI and full GPU ECT callers** (`test-*-openmpi`, `test-gpu-*`) are `workflow_dispatch` only.
 
 ### _test-compiler.yml — Reusable CPU Workflow
 
@@ -90,6 +92,10 @@ Each compiler+MPI combination has a thin caller workflow that invokes a reusable
 ### _test-gpu.yml — Reusable GPU Workflow
 
 Same structure as `_test-compiler.yml` but builds with OpenACC (`openacc: 'true'`) and runs on `CIRRUS-4x8-gpu` self-hosted runners.
+
+### compile-nvhpc-cuda-mpich.yml — CUDA toolchain (compile-only)
+
+Runs on **GitHub-hosted** `ubuntu-latest` inside `CONTAINER_IMAGE_GPU` (NVHPC + MPICH + CUDA). Builds MPAS-A with `openacc: 'true'` and double precision — **no GPU and no model run**. Supplements `_test-gpu.yml` (full ECT on CIRRUS) by catching toolchain breakage on every push/PR.
 
 ### Other Workflows
 

--- a/.github/workflows/compile-nvhpc-cuda-mpich.yml
+++ b/.github/workflows/compile-nvhpc-cuda-mpich.yml
@@ -1,0 +1,58 @@
+# NVHPC + MPICH + CUDA: compile-only on GitHub-hosted runners.
+# Validates the OpenACC/CUDA toolchain (no GPU present; no model run).
+
+name: "NVHPC+MPICH+CUDA (compile-only)"
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  config:
+    name: Resolve CUDA container
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.gpu.outputs.image }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/resolve-container
+        id: gpu
+        with:
+          compiler: nvhpc
+          mpi: mpich
+          gpu: cuda
+
+  compile:
+    needs: config
+    name: Compile (OpenACC, MPICH)
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.config.outputs.image }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: 'true'
+
+      - name: Build MPAS-A (double precision, OpenACC)
+        uses: ./.github/actions/build-mpas
+        with:
+          compiler: nvhpc
+          use-pio: 'false'
+          openacc: 'true'
+          precision: double
+          build-timeout: '45'
+
+      - name: Summary
+        shell: bash
+        run: |
+          echo "## NVHPC + MPICH + CUDA compile-only" >> "$GITHUB_STEP_SUMMARY"
+          echo "Built \`atmosphere_model\` with OpenACC in ${{ needs.config.outputs.image }}." >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Each test builds in double precision, runs 3 perturbed ensemble members (4 MPI r
 | NVHPC | MPICH | GPU | [![NVHPC+MPICH (GPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-mpich.yml) | `hpcdev:almalinux9-nvhpc-mpich-cuda-26.02` |
 | NVHPC | OpenMPI | GPU | [![NVHPC+OpenMPI (GPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-openmpi.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-openmpi.yml) | `hpcdev:almalinux9-nvhpc-openmpi-cuda-26.02` |
 
+GitHub-hosted runners have no GPU. **Compile-only** workflows verify the NVHPC + OpenACC + CUDA toolchain by building MPAS-A (no model run):
+
+| Compiler | MPI | Target | Status | Container |
+|----------|-----|--------|--------|-----------|
+| NVHPC | MPICH | CUDA (compile) | [![NVHPC+MPICH+CUDA (compile-only)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/compile-nvhpc-cuda-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/compile-nvhpc-cuda-mpich.yml) | `hpcdev:almalinux9-nvhpc-mpich-cuda-26.02` |
+
 \* Intel pinned to `hpcdev 25.09` (IFX 2025.2) to avoid an [IFX 2025.3 preprocessor regression](.github/ci-config.env).
 
 ECT subset container images are from [ncarcisl/hpcdev](https://hub.docker.com/r/ncarcisl/hpcdev-x86_64).


### PR DESCRIPTION
Adds compile-nvhpc-cuda-mpich.yml: resolves the CUDA hpcdev image, builds MPAS-A with OpenACC  (no model run). Triggers on push/PR to master/develop and workflow_dispatch. 

