### PR TITLE
Feature ci nsys

### DIFF
--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -100,7 +100,7 @@ Runs on **GitHub-hosted** `ubuntu-latest` inside `CONTAINER_IMAGE_GPU` (NVHPC + 
 
 ### profile-gpu-nsight.yml — Nsight Systems (GPU)
 
-**`workflow_dispatch` only** on `CIRRUS-4x8-gpu` (same security model as `test-gpu-*.yml`). Resolves the CUDA container, builds OpenACC MPAS-A, downloads a test case, then **temporarily lowers `config_dt`** in the test-case namelist so a **very short** `config_run_duration` (defaults: **60s** timestep length and **60s** simulated time — one timestep) still completes a step; then runs `.github/scripts/run-nsys-profile.sh` to execute `nsys profile --trace=cuda,nvtx,osrt --stats=true` around `mpirun`. Uploads the session file (`.nsys-rep` / `.qdrep`) and `nsys stats` text with **3-day** artifact retention. Requires `nsys` on the runner image (PATH or under `/opt/nvidia/nsight-systems`). If the model is unstable at the default dt, increase the `config_dt_seconds` / `run_duration` dispatch inputs.
+**`workflow_dispatch` only** on `CIRRUS-4x8-gpu` (same security model as `test-gpu-*.yml`). Resolves the CUDA container, builds OpenACC MPAS-A, downloads a test case, and overrides **`config_run_duration` only** (`config_dt` is never changed — it is set by science for each resolution). Default duration is **`0_00:12:00`**, i.e. one timestep for the stock **120km** case (`config_dt = 720s`). Then runs `.github/scripts/run-nsys-profile.sh` to execute `nsys profile --trace=cuda,nvtx,osrt --stats=true` around `mpirun`. Uploads the session file (`.nsys-rep` / `.qdrep`) and `nsys stats` text with **3-day** artifact retention. Requires `nsys` on the runner image (PATH or under `/opt/nvidia/nsight-systems`). For other resolutions, set `run_duration` to at least one timestep for that case’s `config_dt`.
 
 ### Other Workflows
 

--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -38,7 +38,7 @@ This is `NCAR/MPAS-Model-CI`, a fork of `MPAS-Dev/MPAS-Model`. The MPAS source c
     ├── test-nvhpc-openmpi.yml   # Caller: NVHPC+OpenMPI (dispatch-only)
     ├── test-gpu-mpich.yml       # Caller: NVHPC+MPICH GPU (dispatch-only)
     ├── test-gpu-openmpi.yml     # Caller: NVHPC+OpenMPI GPU (dispatch-only)
-    ├── compile-nvhpc-cuda-mpich.yml  # NVHPC+MPICH+CUDA compile-only (GA-hosted)
+    ├── compile-nvhpc-cuda-mpich.yml  # NVHPC+MPICH (GPU Compile-only) on GA-hosted runners
     ├── profile-gpu-nsight.yml        # Nsight Systems profile on CIRRUS (dispatch-only)
     ├── ect-test.yml             # Standalone ECT (debugging)
     ├── ect-ensemble-gen.yml     # Generate ensemble summary (manual, expensive)
@@ -78,7 +78,7 @@ Each compiler+MPI combination has a thin caller workflow that invokes a reusable
 - **GPU subsets** call `_test-gpu.yml` with `mpi` input (always NVHPC)
 
 **MPICH callers** (`test-gcc-mpich`, `test-intel-mpich`, `test-nvhpc-mpich`) run on push/PR to `master`/`develop`.
-**compile-nvhpc-cuda-mpich** (NVHPC + OpenACC compile-only on GitHub-hosted runners) also runs on push/PR.
+**compile-nvhpc-cuda-mpich** (**NVHPC+MPICH (GPU Compile-only)** — OpenACC on GitHub-hosted runners) also runs on push/PR.
 **OpenMPI and full GPU ECT callers** (`test-*-openmpi`, `test-gpu-*`) are `workflow_dispatch` only.
 
 ### _test-compiler.yml — Reusable CPU Workflow
@@ -94,7 +94,7 @@ Each compiler+MPI combination has a thin caller workflow that invokes a reusable
 
 Same structure as `_test-compiler.yml` but builds with OpenACC (`openacc: 'true'`) and runs on `CIRRUS-4x8-gpu` self-hosted runners.
 
-### compile-nvhpc-cuda-mpich.yml — CUDA toolchain (compile-only)
+### compile-nvhpc-cuda-mpich.yml — NVHPC+MPICH (GPU Compile-only)
 
 Runs on **GitHub-hosted** `ubuntu-latest` inside `CONTAINER_IMAGE_GPU` (NVHPC + MPICH + CUDA). Builds MPAS-A with `openacc: 'true'` and double precision — **no GPU and no model run**. Supplements `_test-gpu.yml` (full ECT on CIRRUS) by catching toolchain breakage on every push/PR.
 

--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -39,6 +39,7 @@ This is `NCAR/MPAS-Model-CI`, a fork of `MPAS-Dev/MPAS-Model`. The MPAS source c
     ├── test-gpu-mpich.yml       # Caller: NVHPC+MPICH GPU (dispatch-only)
     ├── test-gpu-openmpi.yml     # Caller: NVHPC+OpenMPI GPU (dispatch-only)
     ├── compile-nvhpc-cuda-mpich.yml  # NVHPC+MPICH+CUDA compile-only (GA-hosted)
+    ├── profile-gpu-nsight.yml        # Nsight Systems profile on CIRRUS (dispatch-only)
     ├── ect-test.yml             # Standalone ECT (debugging)
     ├── ect-ensemble-gen.yml     # Generate ensemble summary (manual, expensive)
     ├── coverage.yml             # GCC coverage + Codecov upload
@@ -96,6 +97,10 @@ Same structure as `_test-compiler.yml` but builds with OpenACC (`openacc: 'true'
 ### compile-nvhpc-cuda-mpich.yml — CUDA toolchain (compile-only)
 
 Runs on **GitHub-hosted** `ubuntu-latest` inside `CONTAINER_IMAGE_GPU` (NVHPC + MPICH + CUDA). Builds MPAS-A with `openacc: 'true'` and double precision — **no GPU and no model run**. Supplements `_test-gpu.yml` (full ECT on CIRRUS) by catching toolchain breakage on every push/PR.
+
+### profile-gpu-nsight.yml — Nsight Systems (GPU)
+
+**`workflow_dispatch` only** on `CIRRUS-4x8-gpu` (same security model as `test-gpu-*.yml`). Resolves the CUDA container, builds OpenACC MPAS-A, downloads a test case, then runs `.github/scripts/run-nsys-profile.sh` to execute `nsys profile --trace=cuda,nvtx,osrt --stats=true` around `mpirun`. Uploads the session file (`.nsys-rep` / `.qdrep`) and `nsys stats` text with **3-day** artifact retention. Requires `nsys` on the runner image (PATH or under `/opt/nvidia/nsight-systems`).
 
 ### Other Workflows
 
@@ -203,7 +208,7 @@ Workflows accept `mpas-repository` and `mpas-ref` inputs for testing upstream MP
 
 ## Security
 
-- **Self-hosted runners**: GPU workflows use `workflow_dispatch` only. Never add `pull_request` triggers — fork PRs could execute arbitrary code on CIRRUS hardware.
+- **Self-hosted runners**: GPU workflows (`_test-gpu`, `test-gpu-*`, `profile-gpu-nsight`) use `workflow_dispatch` only. Never add `pull_request` triggers — fork PRs could execute arbitrary code on CIRRUS hardware.
 - **Secret isolation**: Test data is public release assets on this repo, so CI does not need a separate data-repo PAT for downloads.
 - **Cross-repo execution**: `workflow_dispatch` with external repo inputs runs `make` from that repo. Acceptable since only write-access users can trigger it.
 

--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -100,7 +100,7 @@ Runs on **GitHub-hosted** `ubuntu-latest` inside `CONTAINER_IMAGE_GPU` (NVHPC + 
 
 ### profile-gpu-nsight.yml — Nsight Systems (GPU)
 
-**`workflow_dispatch` only** on `CIRRUS-4x8-gpu` (same security model as `test-gpu-*.yml`). Resolves the CUDA container, builds OpenACC MPAS-A, downloads a test case, then runs `.github/scripts/run-nsys-profile.sh` to execute `nsys profile --trace=cuda,nvtx,osrt --stats=true` around `mpirun`. Uploads the session file (`.nsys-rep` / `.qdrep`) and `nsys stats` text with **3-day** artifact retention. Requires `nsys` on the runner image (PATH or under `/opt/nvidia/nsight-systems`).
+**`workflow_dispatch` only** on `CIRRUS-4x8-gpu` (same security model as `test-gpu-*.yml`). Resolves the CUDA container, builds OpenACC MPAS-A, downloads a test case, then **temporarily lowers `config_dt`** in the test-case namelist so a **very short** `config_run_duration` (defaults: **60s** timestep length and **60s** simulated time — one timestep) still completes a step; then runs `.github/scripts/run-nsys-profile.sh` to execute `nsys profile --trace=cuda,nvtx,osrt --stats=true` around `mpirun`. Uploads the session file (`.nsys-rep` / `.qdrep`) and `nsys stats` text with **3-day** artifact retention. Requires `nsys` on the runner image (PATH or under `/opt/nvidia/nsight-systems`). If the model is unstable at the default dt, increase the `config_dt_seconds` / `run_duration` dispatch inputs.
 
 ### Other Workflows
 

--- a/.github/scripts/resolve-nsys.sh
+++ b/.github/scripts/resolve-nsys.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Pick a working `nsys` binary. NVHPC may put a stub first on PATH that fails with
+# "nsys-Error-Version ... Nsight_Systems/bin is not available in this installation";
+# we prefer /opt/nvidia/nsight-systems or CUDA toolkit paths and test with `nsys --version`.
+#
+# Usage: source this file from bash, then call resolve_nsys.
+# On success: exports NSYS_BIN to the chosen executable.
+# shellcheck shell=bash
+
+resolve_nsys() {
+  local prepend="" d dir
+  local -a dirs
+
+  shopt -s nullglob
+  for d in /opt/nvidia/nsight-systems/*/bin /usr/local/cuda/bin /usr/local/cuda-*/bin; do
+    [ -d "$d" ] && prepend="${prepend}${d}:"
+  done
+  shopt -u nullglob
+
+  export PATH="${prepend}${PATH}"
+
+  IFS=':' read -ra dirs <<< "${PATH}"
+  for dir in "${dirs[@]}"; do
+    [ -z "$dir" ] && continue
+    [ -x "${dir}/nsys" ] || continue
+    if "${dir}/nsys" --version &>/dev/null; then
+      NSYS_BIN="${dir}/nsys"
+      export NSYS_BIN
+      return 0
+    fi
+  done
+
+  # Explicit paths (some images omit standard entries from PATH)
+  local c
+  shopt -s nullglob
+  for c in /opt/nvidia/nsight-systems/*/bin/nsys /usr/local/cuda/bin/nsys /usr/local/cuda-*/bin/nsys; do
+    [ -x "$c" ] || continue
+    if "$c" --version &>/dev/null; then
+      NSYS_BIN="$c"
+      export NSYS_BIN
+      shopt -u nullglob
+      return 0
+    fi
+  done
+  shopt -u nullglob
+  return 1
+}

--- a/.github/scripts/run-nsys-profile.sh
+++ b/.github/scripts/run-nsys-profile.sh
@@ -25,21 +25,24 @@ if [ -f "${CI_CONFIG}" ]; then
   source "${CI_CONFIG}"
 fi
 
-# Locate nsys (not always on default PATH in minimal images)
-if ! command -v nsys &>/dev/null; then
-  for d in /opt/nvidia/nsight-systems/*/bin /usr/local/cuda/bin /usr/local/cuda-*/bin; do
-    if [ -d "$d" ]; then
-      export PATH="${d}:${PATH}"
-    fi
-  done
-fi
-if ! command -v nsys &>/dev/null; then
-  echo "::error::nsys (Nsight Systems) not found. Install Nsight Systems or use an image that includes it."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/resolve-nsys.sh"
+
+if ! resolve_nsys; then
+  echo "::error::No working nsys found. NVHPC may expose a stub that fails with Nsight version errors;"
+  echo "::error::install a full Nsight Systems build under /opt/nvidia/nsight-systems or ensure CUDA toolkit nsys is on PATH."
   exit 1
 fi
 
-echo "=== nsys ==="
-nsys --version
+echo "=== nsys (${NSYS_BIN}) ==="
+"${NSYS_BIN}" --version
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+  {
+    echo "NSYS_BIN=${NSYS_BIN}"
+  } >> "${GITHUB_ENV}"
+fi
 
 MPI_FLAGS=""
 if [ "${MPI_IMPL}" = "openmpi" ]; then
@@ -62,7 +65,7 @@ echo "  output:  ${OUT_ABS}"
 echo "  timeout: ${TIMEOUT}m"
 
 set +e
-timeout "${TIMEOUT}"m nsys profile \
+timeout "${TIMEOUT}"m "${NSYS_BIN}" profile \
   --trace=cuda,nvtx,osrt \
   --stats=true \
   -o "${OUT_ABS}" \

--- a/.github/scripts/run-nsys-profile.sh
+++ b/.github/scripts/run-nsys-profile.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Run MPAS-A under Nsight Systems (nsys profile). Intended for CIRRUS GPU CI.
+# Usage: run-nsys-profile.sh <workdir> <num-procs> <mpi-impl> <timeout-minutes> <nsys-output-basename>
+set -euo pipefail
+
+WORKDIR="${1:?workdir required}"
+NUM_PROCS="${2:?num-procs required}"
+MPI_IMPL="${3:?mpi-impl required}"
+TIMEOUT="${4:?timeout minutes required}"
+NSYS_BASENAME="${5:?nsys output basename required}"
+
+if [ -f /container/config_env.sh ]; then
+  # shellcheck source=/dev/null
+  source /container/config_env.sh
+fi
+
+if [ -z "${LD_LIBRARY_PATH:-}" ]; then
+  export LD_LIBRARY_PATH="/usr/lib64:/usr/lib"
+fi
+
+REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+CI_CONFIG="${REPO_ROOT}/.github/ci-config.env"
+if [ -f "${CI_CONFIG}" ]; then
+  # shellcheck source=/dev/null
+  source "${CI_CONFIG}"
+fi
+
+# Locate nsys (not always on default PATH in minimal images)
+if ! command -v nsys &>/dev/null; then
+  for d in /opt/nvidia/nsight-systems/*/bin /usr/local/cuda/bin /usr/local/cuda-*/bin; do
+    if [ -d "$d" ]; then
+      export PATH="${d}:${PATH}"
+    fi
+  done
+fi
+if ! command -v nsys &>/dev/null; then
+  echo "::error::nsys (Nsight Systems) not found. Install Nsight Systems or use an image that includes it."
+  exit 1
+fi
+
+echo "=== nsys ==="
+nsys --version
+
+MPI_FLAGS=""
+if [ "${MPI_IMPL}" = "openmpi" ]; then
+  MPI_FLAGS="${OPENMPI_RUN_FLAGS:---allow-run-as-root --oversubscribe}"
+elif [ "${MPI_IMPL}" = "mpich" ]; then
+  export MPICH_GPU_SUPPORT_ENABLED="${MPICH_RUN_ENV_MPICH_GPU_SUPPORT_ENABLED:-0}"
+  export MPIR_CVAR_ENABLE_GPU="${MPICH_RUN_ENV_MPIR_CVAR_ENABLE_GPU:-0}"
+fi
+
+ulimit -s unlimited 2>/dev/null || true
+
+cd "${WORKDIR}"
+
+OUT_ABS="${PWD}/${NSYS_BASENAME}"
+echo "=== Nsight profile ==="
+echo "  workdir: ${WORKDIR}"
+echo "  ranks:   ${NUM_PROCS}"
+echo "  mpi:     ${MPI_IMPL}"
+echo "  output:  ${OUT_ABS}"
+echo "  timeout: ${TIMEOUT}m"
+
+set +e
+timeout "${TIMEOUT}"m nsys profile \
+  --trace=cuda,nvtx,osrt \
+  --stats=true \
+  -o "${OUT_ABS}" \
+  mpirun -n "${NUM_PROCS}" ${MPI_FLAGS} ./atmosphere_model
+RUN_STATUS=$?
+set -e
+
+if [ "${RUN_STATUS}" -ne 0 ]; then
+  echo "::warning::Profiled run exited with status ${RUN_STATUS}"
+  exit "${RUN_STATUS}"
+fi
+
+echo "=== nsys profile finished ==="
+ls -la "${NSYS_BASENAME}".* 2>/dev/null || ls -la ./*.nsys-rep 2>/dev/null || true

--- a/.github/workflows/compile-nvhpc-cuda-mpich.yml
+++ b/.github/workflows/compile-nvhpc-cuda-mpich.yml
@@ -1,7 +1,7 @@
 # NVHPC + MPICH + CUDA: compile-only on GitHub-hosted runners.
 # Validates the OpenACC/CUDA toolchain (no GPU present; no model run).
 
-name: "NVHPC+MPICH+CUDA (compile-only)"
+name: "NVHPC+MPICH (GPU Compile-only)"
 
 permissions:
   contents: read
@@ -54,5 +54,5 @@ jobs:
       - name: Summary
         shell: bash
         run: |
-          echo "## NVHPC + MPICH + CUDA compile-only" >> "$GITHUB_STEP_SUMMARY"
+          echo "## NVHPC+MPICH (GPU Compile-only)" >> "$GITHUB_STEP_SUMMARY"
           echo "Built \`atmosphere_model\` with OpenACC in ${{ needs.config.outputs.image }}." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/profile-gpu-nsight.yml
+++ b/.github/workflows/profile-gpu-nsight.yml
@@ -1,6 +1,6 @@
-# Nsight Systems GPU profiling on CIRRUS (very short MPAS-A run, CLI stats + small artifacts).
-# The 120km archive uses config_dt=720s; we temporarily lower config_dt so a brief
-# config_run_duration still completes at least one timestep (profiling-only).
+# Nsight Systems GPU profiling on CIRRUS (short MPAS-A run, CLI stats + small artifacts).
+# Only config_run_duration is overridden — never config_dt (science-controlled per resolution).
+# Default duration matches one timestep for the stock 120km case (dt=720s → 0_00:12:00).
 # Security: self-hosted GPU — workflow_dispatch only (same policy as test-gpu-*.yml).
 
 name: GPU Nsight (profile)
@@ -30,20 +30,15 @@ on:
         required: false
         default: '4'
         type: string
-      config_dt_seconds:
-        description: Temporary config_dt (seconds) for profiling — must be <= run_duration in seconds
-        required: false
-        default: '60'
-        type: string
       run_duration:
-        description: config_run_duration (default one timestep at default config_dt; 0_00:01:00 = 60s simulated)
+        description: config_run_duration only (namelist dt unchanged). Default 0_00:12:00 = one timestep for stock 120km (config_dt=720s). Override if you use another resolution.
         required: false
-        default: '0_00:01:00'
+        default: '0_00:12:00'
         type: string
       run_timeout_minutes:
         description: Wall-clock timeout for mpirun + nsys
         required: false
-        default: '8'
+        default: '25'
         type: string
 
 jobs:
@@ -122,17 +117,14 @@ jobs:
           resolution: ${{ inputs.resolution }}
           dest-dir: nsight-case
 
-      - name: Link executable and namelist (brief profiling)
+      - name: Link executable and config_run_duration (dt unchanged)
         shell: bash
         run: |
           chmod +x atmosphere_model
           ln -sf "$(pwd)/atmosphere_model" nsight-case/atmosphere_model
-          DT="${{ inputs.config_dt_seconds }}"
           DURATION="${{ inputs.run_duration }}"
-          sed -i "s/config_dt = [0-9.]*/config_dt = ${DT}/" nsight-case/namelist.atmosphere
           sed -i "s/config_run_duration = '[^']*'/config_run_duration = '${DURATION}'/" nsight-case/namelist.atmosphere
-          echo "config_dt -> ${DT}"
-          echo "config_run_duration -> ${DURATION}"
+          echo "config_run_duration -> ${DURATION} (config_dt left as in test case)"
           grep -E 'config_dt|config_run_duration' nsight-case/namelist.atmosphere | head -n 5
 
       - name: Run nsys profile
@@ -181,7 +173,6 @@ jobs:
             echo "- MPI: ${{ inputs.mpi }}"
             echo "- Resolution: ${{ inputs.resolution }}"
             echo "- Ranks: ${{ inputs.num_procs }}"
-            echo "- config_dt (profiling): ${{ inputs.config_dt_seconds }} s"
             echo "- config_run_duration: ${{ inputs.run_duration }}"
             echo ""
             echo "Session files and \`nsys stats\` text are uploaded as artifacts (short retention)."

--- a/.github/workflows/profile-gpu-nsight.yml
+++ b/.github/workflows/profile-gpu-nsight.yml
@@ -142,15 +142,15 @@ jobs:
         shell: bash
         working-directory: nsight-case
         run: |
-          if ! command -v nsys &>/dev/null; then
-            for d in /opt/nvidia/nsight-systems/*/bin /usr/local/cuda/bin /usr/local/cuda-*/bin; do
-              [ -d "$d" ] && export PATH="$d:$PATH"
-            done
+          if [ -f /container/config_env.sh ]; then
+            source /container/config_env.sh
           fi
-          if ! command -v nsys &>/dev/null; then
-            echo "::warning::nsys not found; skipping nsys stats generation"
+          source "${GITHUB_WORKSPACE}/.github/scripts/resolve-nsys.sh"
+          if ! resolve_nsys; then
+            echo "::warning::No working nsys; skipping nsys stats generation"
             exit 0
           fi
+          echo "Using nsys: ${NSYS_BIN}"
           shopt -s nullglob
           REP=""
           for f in nsys-profile.nsys-rep *.nsys-rep *.qdrep; do
@@ -165,8 +165,8 @@ jobs:
             exit 0
           fi
           echo "=== nsys stats (first 200 lines): ${REP} ==="
-          nsys stats "${REP}" 2>&1 | head -n 200
-          nsys stats "${REP}" > "nsys-profile-stats.txt" 2>&1 || true
+          "${NSYS_BIN}" stats "${REP}" 2>&1 | head -n 200
+          "${NSYS_BIN}" stats "${REP}" > "nsys-profile-stats.txt" 2>&1 || true
 
       - name: Job summary
         if: always()

--- a/.github/workflows/profile-gpu-nsight.yml
+++ b/.github/workflows/profile-gpu-nsight.yml
@@ -1,0 +1,188 @@
+# Nsight Systems GPU profiling on CIRRUS (short MPAS-A run, CLI stats + small artifacts).
+# Security: self-hosted GPU — workflow_dispatch only (same policy as test-gpu-*.yml).
+
+name: GPU Nsight (profile)
+
+permissions:
+  contents: read
+  actions: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      mpi:
+        description: MPI implementation
+        required: true
+        default: mpich
+        type: choice
+        options:
+          - mpich
+          - openmpi
+      resolution:
+        description: Test case resolution (see RELEASE_TESTDATA_* in ci-config.env)
+        required: false
+        default: '120km'
+        type: string
+      num_procs:
+        description: MPI rank count
+        required: false
+        default: '4'
+        type: string
+      run_duration:
+        description: config_run_duration override (keep short for profiling)
+        required: false
+        default: '0_00:02:00'
+        type: string
+      run_timeout_minutes:
+        description: Wall-clock timeout for mpirun + nsys
+        required: false
+        default: '20'
+        type: string
+
+jobs:
+  config:
+    name: Resolve CUDA container
+    runs-on: ubuntu-latest
+    outputs:
+      image-gpu: ${{ steps.gpu-container.outputs.image }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/resolve-container
+        id: gpu-container
+        with:
+          compiler: nvhpc
+          mpi: ${{ inputs.mpi }}
+          gpu: cuda
+
+  build:
+    needs: config
+    name: Build (cuda, ${{ inputs.mpi }})
+    runs-on:
+      group: CIRRUS-4x8-gpu
+    container:
+      image: ${{ needs.config.outputs.image-gpu }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: 'true'
+
+      - name: Build MPAS-A (double precision, OpenACC)
+        uses: ./.github/actions/build-mpas
+        with:
+          compiler: nvhpc
+          use-pio: 'false'
+          openacc: 'true'
+          precision: double
+          build-timeout: '45'
+
+      - name: Upload executable
+        uses: actions/upload-artifact@v6
+        with:
+          name: exe-profile-nsight-${{ inputs.mpi }}
+          path: atmosphere_model
+          retention-days: 1
+
+  profile:
+    needs: [config, build]
+    if: ${{ needs.build.result == 'success' }}
+    name: Nsight profile (${{ inputs.mpi }})
+    runs-on:
+      group: CIRRUS-4x8-gpu
+    container:
+      image: ${{ needs.config.outputs.image-gpu }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: GPU check
+        shell: bash
+        run: |
+          echo "## GPU" >> "$GITHUB_STEP_SUMMARY"
+          nvidia-smi || echo "::warning::nvidia-smi failed"
+          nvidia-smi || true
+
+      - name: Download executable
+        uses: actions/download-artifact@v7
+        with:
+          name: exe-profile-nsight-${{ inputs.mpi }}
+
+      - name: Download test case
+        uses: ./.github/actions/download-testdata
+        with:
+          resolution: ${{ inputs.resolution }}
+          dest-dir: nsight-case
+
+      - name: Link executable and configure
+        shell: bash
+        run: |
+          chmod +x atmosphere_model
+          ln -sf "$(pwd)/atmosphere_model" nsight-case/atmosphere_model
+          DURATION="${{ inputs.run_duration }}"
+          sed -i "s/config_run_duration = '[^']*'/config_run_duration = '${DURATION}'/" nsight-case/namelist.atmosphere
+          echo "config_run_duration -> ${DURATION}"
+          grep config_run_duration nsight-case/namelist.atmosphere
+
+      - name: Run nsys profile
+        shell: bash
+        run: |
+          chmod +x .github/scripts/run-nsys-profile.sh
+          bash .github/scripts/run-nsys-profile.sh \
+            nsight-case \
+            "${{ inputs.num_procs }}" \
+            "${{ inputs.mpi }}" \
+            "${{ inputs.run_timeout_minutes }}" \
+            nsys-profile
+
+      - name: nsys stats (text)
+        shell: bash
+        working-directory: nsight-case
+        run: |
+          if ! command -v nsys &>/dev/null; then
+            for d in /opt/nvidia/nsight-systems/*/bin /usr/local/cuda/bin; do
+              [ -d "$d" ] && export PATH="$d:$PATH"
+            done
+          fi
+          shopt -s nullglob
+          REP=""
+          for f in nsys-profile.nsys-rep *.nsys-rep *.qdrep; do
+            if [ -f "$f" ]; then
+              REP="$f"
+              break
+            fi
+          done
+          if [ -z "${REP}" ]; then
+            echo "::warning::No Nsight session file found for nsys stats"
+            ls -la
+            exit 0
+          fi
+          echo "=== nsys stats (first 200 lines): ${REP} ==="
+          nsys stats "${REP}" 2>&1 | head -n 200
+          nsys stats "${REP}" > "nsys-profile-stats.txt" 2>&1 || true
+
+      - name: Job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Nsight profile"
+            echo "- MPI: ${{ inputs.mpi }}"
+            echo "- Resolution: ${{ inputs.resolution }}"
+            echo "- Ranks: ${{ inputs.num_procs }}"
+            echo "- Duration: ${{ inputs.run_duration }}"
+            echo ""
+            echo "Session files and \`nsys stats\` text are uploaded as artifacts (short retention)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Nsight artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: nsys-profile-${{ github.run_id }}-${{ inputs.mpi }}
+          path: |
+            nsight-case/nsys-profile.*
+            nsight-case/nsys-profile-stats.txt
+          retention-days: 3
+          if-no-files-found: warn

--- a/.github/workflows/profile-gpu-nsight.yml
+++ b/.github/workflows/profile-gpu-nsight.yml
@@ -143,9 +143,13 @@ jobs:
         working-directory: nsight-case
         run: |
           if ! command -v nsys &>/dev/null; then
-            for d in /opt/nvidia/nsight-systems/*/bin /usr/local/cuda/bin; do
+            for d in /opt/nvidia/nsight-systems/*/bin /usr/local/cuda/bin /usr/local/cuda-*/bin; do
               [ -d "$d" ] && export PATH="$d:$PATH"
             done
+          fi
+          if ! command -v nsys &>/dev/null; then
+            echo "::warning::nsys not found; skipping nsys stats generation"
+            exit 0
           fi
           shopt -s nullglob
           REP=""

--- a/.github/workflows/profile-gpu-nsight.yml
+++ b/.github/workflows/profile-gpu-nsight.yml
@@ -1,7 +1,4 @@
-# Nsight Systems GPU profiling on CIRRUS (short MPAS-A run, CLI stats + small artifacts).
-# Only config_run_duration is overridden — never config_dt (science-controlled per resolution).
-# Default duration matches one timestep for the stock 120km case (dt=720s → 0_00:12:00).
-# Security: self-hosted GPU — workflow_dispatch only (same policy as test-gpu-*.yml).
+# Nsight Systems GPU profiling on CIRRUS (keep to very short runs)
 
 name: GPU Nsight (profile)
 

--- a/.github/workflows/profile-gpu-nsight.yml
+++ b/.github/workflows/profile-gpu-nsight.yml
@@ -1,4 +1,6 @@
-# Nsight Systems GPU profiling on CIRRUS (short MPAS-A run, CLI stats + small artifacts).
+# Nsight Systems GPU profiling on CIRRUS (very short MPAS-A run, CLI stats + small artifacts).
+# The 120km archive uses config_dt=720s; we temporarily lower config_dt so a brief
+# config_run_duration still completes at least one timestep (profiling-only).
 # Security: self-hosted GPU — workflow_dispatch only (same policy as test-gpu-*.yml).
 
 name: GPU Nsight (profile)
@@ -28,15 +30,20 @@ on:
         required: false
         default: '4'
         type: string
-      run_duration:
-        description: config_run_duration override (keep short for profiling)
+      config_dt_seconds:
+        description: Temporary config_dt (seconds) for profiling — must be <= run_duration in seconds
         required: false
-        default: '0_00:02:00'
+        default: '60'
+        type: string
+      run_duration:
+        description: config_run_duration (default one timestep at default config_dt; 0_00:01:00 = 60s simulated)
+        required: false
+        default: '0_00:01:00'
         type: string
       run_timeout_minutes:
         description: Wall-clock timeout for mpirun + nsys
         required: false
-        default: '20'
+        default: '8'
         type: string
 
 jobs:
@@ -115,15 +122,18 @@ jobs:
           resolution: ${{ inputs.resolution }}
           dest-dir: nsight-case
 
-      - name: Link executable and configure
+      - name: Link executable and namelist (brief profiling)
         shell: bash
         run: |
           chmod +x atmosphere_model
           ln -sf "$(pwd)/atmosphere_model" nsight-case/atmosphere_model
+          DT="${{ inputs.config_dt_seconds }}"
           DURATION="${{ inputs.run_duration }}"
+          sed -i "s/config_dt = [0-9.]*/config_dt = ${DT}/" nsight-case/namelist.atmosphere
           sed -i "s/config_run_duration = '[^']*'/config_run_duration = '${DURATION}'/" nsight-case/namelist.atmosphere
+          echo "config_dt -> ${DT}"
           echo "config_run_duration -> ${DURATION}"
-          grep config_run_duration nsight-case/namelist.atmosphere
+          grep -E 'config_dt|config_run_duration' nsight-case/namelist.atmosphere | head -n 5
 
       - name: Run nsys profile
         shell: bash
@@ -171,7 +181,8 @@ jobs:
             echo "- MPI: ${{ inputs.mpi }}"
             echo "- Resolution: ${{ inputs.resolution }}"
             echo "- Ranks: ${{ inputs.num_procs }}"
-            echo "- Duration: ${{ inputs.run_duration }}"
+            echo "- config_dt (profiling): ${{ inputs.config_dt_seconds }} s"
+            echo "- config_run_duration: ${{ inputs.run_duration }}"
             echo ""
             echo "Session files and \`nsys stats\` text are uploaded as artifacts (short retention)."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ GitHub-hosted runners have no GPU. **Compile-only** workflows verify the NVHPC +
 
 | Compiler | MPI | Target | Status | Container |
 |----------|-----|--------|--------|-----------|
-| NVHPC | MPICH | CUDA (compile) | [![NVHPC+MPICH+CUDA (compile-only)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/compile-nvhpc-cuda-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/compile-nvhpc-cuda-mpich.yml) | `hpcdev:almalinux9-nvhpc-mpich-cuda-26.02` |
+| NVHPC | MPICH | CUDA (compile) | [![NVHPC+MPICH (GPU Compile-only)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/compile-nvhpc-cuda-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/compile-nvhpc-cuda-mpich.yml) | `hpcdev:almalinux9-nvhpc-mpich-cuda-26.02` |
 
 **GPU profiling (CIRRUS)** — `nsys profile` on a short run (`config_run_duration` only; `config_dt` unchanged) plus `nsys stats` text; `workflow_dispatch` only; artifacts kept a few days.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ GitHub-hosted runners have no GPU. **Compile-only** workflows verify the NVHPC +
 |----------|-----|--------|--------|-----------|
 | NVHPC | MPICH | CUDA (compile) | [![NVHPC+MPICH+CUDA (compile-only)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/compile-nvhpc-cuda-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/compile-nvhpc-cuda-mpich.yml) | `hpcdev:almalinux9-nvhpc-mpich-cuda-26.02` |
 
+**GPU profiling (CIRRUS)** — short `nsys profile` run plus `nsys stats` text; `workflow_dispatch` only; artifacts kept a few days.
+
+| Workflow | Status |
+|----------|--------|
+| GPU Nsight (profile) | [![GPU Nsight (profile)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/profile-gpu-nsight.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/profile-gpu-nsight.yml) |
+
 \* Intel pinned to `hpcdev 25.09` (IFX 2025.2) to avoid an [IFX 2025.3 preprocessor regression](.github/ci-config.env).
 
 ECT subset container images are from [ncarcisl/hpcdev](https://hub.docker.com/r/ncarcisl/hpcdev-x86_64).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GitHub-hosted runners have no GPU. **Compile-only** workflows verify the NVHPC +
 |----------|-----|--------|--------|-----------|
 | NVHPC | MPICH | CUDA (compile) | [![NVHPC+MPICH+CUDA (compile-only)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/compile-nvhpc-cuda-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/compile-nvhpc-cuda-mpich.yml) | `hpcdev:almalinux9-nvhpc-mpich-cuda-26.02` |
 
-**GPU profiling (CIRRUS)** — brief `nsys profile` run (default one small timestep via reduced `config_dt`) plus `nsys stats` text; `workflow_dispatch` only; artifacts kept a few days.
+**GPU profiling (CIRRUS)** — `nsys profile` on a short run (`config_run_duration` only; `config_dt` unchanged) plus `nsys stats` text; `workflow_dispatch` only; artifacts kept a few days.
 
 | Workflow | Status |
 |----------|--------|

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GitHub-hosted runners have no GPU. **Compile-only** workflows verify the NVHPC +
 |----------|-----|--------|--------|-----------|
 | NVHPC | MPICH | CUDA (compile) | [![NVHPC+MPICH+CUDA (compile-only)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/compile-nvhpc-cuda-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/compile-nvhpc-cuda-mpich.yml) | `hpcdev:almalinux9-nvhpc-mpich-cuda-26.02` |
 
-**GPU profiling (CIRRUS)** — short `nsys profile` run plus `nsys stats` text; `workflow_dispatch` only; artifacts kept a few days.
+**GPU profiling (CIRRUS)** — brief `nsys profile` run (default one small timestep via reduced `config_dt`) plus `nsys stats` text; `workflow_dispatch` only; artifacts kept a few days.
 
 | Workflow | Status |
 |----------|--------|


### PR DESCRIPTION
Manual-only GPU workflow that builds MPAS-A with NVHPC + OpenACC in the CUDA hpcdev image,
runs a very short atmosphere case under nsys profile. Default resolution 120km, config_run_duration 0_00:12:00
so the run covers one dynamical timestep. Dispatch inputs allow a different resolution or duration when needed.

Helper script .github/scripts/run-nsys-profile.sh wraps mpirun with the same MPI environment pattern as run-mpas
