### PR TITLE
Modular CI: shared NVHPC container resolution + maintainer docs

### DIFF
--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -6,6 +6,12 @@ MPAS (Model for Prediction Across Scales) is a community atmospheric model used 
 
 MPAS has consistent coding conventions maintained over many years. Follow existing style.
 
+## Who this guide is for
+
+- **Students / new contributors** — Start with [Subset workflows](#subset-workflows-primary-ci) and the [test-* caller](#subset-workflows-primary-ci) you care about. Change compiler/MPI by picking a different caller or inputs; do not edit reusable templates until you understand the flow.
+- **Scientists** — Namelist and physics settings live in test-case archives and `ci-config.env` (`ECT_*`, `BFB_*`). CI may override **`config_run_duration`** for short runs; **`config_dt`** is not changed by our profiling workflows (science-controlled per resolution).
+- **Software engineers** — See [docs/ci-workflow-map.md](../docs/ci-workflow-map.md) for the full caller → reusable → composite map, [docs/ci-template-notes.md](../docs/ci-template-notes.md) for porting patterns to other NCAR repos, and the workflow graph below.
+
 ## Repository Layout
 
 This is `NCAR/MPAS-Model-CI`, a fork of `MPAS-Dev/MPAS-Model`. The MPAS source code (Fortran, `src/`, `Makefile`) is inherited from upstream. CI infrastructure lives in `.github/`.
@@ -30,6 +36,7 @@ This is `NCAR/MPAS-Model-CI`, a fork of `MPAS-Dev/MPAS-Model`. The MPAS source c
 └── workflows/
     ├── _test-compiler.yml       # Reusable: CPU build + ECT validation
     ├── _test-gpu.yml            # Reusable: GPU build + ECT validation (CIRRUS)
+    ├── _resolve-nvhpc-containers.yml  # Reusable: NVHPC CPU + CUDA image names
     ├── test-gcc-mpich.yml       # Caller: GNU+MPICH (auto on push/PR)
     ├── test-gcc-openmpi.yml     # Caller: GNU+OpenMPI (dispatch-only)
     ├── test-intel-mpich.yml     # Caller: Intel+MPICH (auto on push/PR)
@@ -43,6 +50,10 @@ This is `NCAR/MPAS-Model-CI`, a fork of `MPAS-Dev/MPAS-Model`. The MPAS source c
     ├── ect-ensemble-gen.yml     # Generate ensemble summary (manual, expensive)
     ├── coverage.yml             # GCC coverage + Codecov upload
     └── unit-tests.yml           # pFUnit unit tests
+
+docs/                            # CI documentation (repo root)
+├── ci-workflow-map.md           # Caller vs reusable inventory
+└── ci-template-notes.md         # Forking CI for other NCAR projects
 
 tests/                           # pFUnit test infrastructure (repo root)
 ├── CMakeLists.txt
@@ -65,7 +76,7 @@ Current tags: `testdata-240km-v1`, `testdata-120km-v1`, `ect-summary-v1`, `ect-r
 
 - **`master`** — default branch, mirrors upstream MPAS-Model. Workflow files must exist here for the `workflow_dispatch` UI button to appear.
 - **`develop`** — upstream develop branch.
-- **`feature-ci-cleanup`** — active development branch for CI improvements. PR #18 targets master.
+- **`feature-ci-cleanup`** — branch for modular CI refactors and docs (subset structure, reusable workflows).
 
 ## Workflow Architecture
 
@@ -80,6 +91,22 @@ Each compiler+MPI combination has a thin caller workflow that invokes a reusable
 **compile-nvhpc-cuda-mpich** (NVHPC + OpenACC compile-only on GitHub-hosted runners) also runs on push/PR.
 **OpenMPI and full GPU ECT callers** (`test-*-openmpi`, `test-gpu-*`) are `workflow_dispatch` only.
 
+### Workflow graph (NVHPC GPU path)
+
+Thin callers invoke reusable workflows; container names always come from `ci-config.env` via `resolve-container` (bundled inside `_resolve-nvhpc-containers` for NVHPC):
+
+```mermaid
+flowchart TB
+  caller[test-gpu-*.yml caller]
+  gpuWF[_test-gpu.yml]
+  resolveWF[_resolve-nvhpc-containers.yml]
+  cfg[ci-config.env]
+
+  caller --> gpuWF
+  gpuWF --> resolveWF
+  resolveWF --> cfg
+```
+
 ### _test-compiler.yml — Reusable CPU Workflow
 
 **Job flow**: `config` → `build` → `ect-run` (3 parallel members) → `ect-validate` → `cleanup`
@@ -92,6 +119,10 @@ Each compiler+MPI combination has a thin caller workflow that invokes a reusable
 ### _test-gpu.yml — Reusable GPU Workflow
 
 Same structure as `_test-compiler.yml` but builds with OpenACC (`openacc: 'true'`) and runs on `CIRRUS-4x8-gpu` self-hosted runners.
+
+### _resolve-nvhpc-containers.yml — Reusable NVHPC image resolution
+
+Runs on `ubuntu-latest`, checks out `.github` only, and calls **`resolve-container`** twice (NVHPC + MPI for CPU image, NVHPC + MPI + CUDA for GPU image). Exposes outputs **`image_cpu`** and **`image_gpu`**. Used by **`_test-gpu.yml`** (GPU jobs consume **`image_gpu`**) and **`compile-nvhpc-cuda-mpich.yml`** (compile job uses **`image_gpu`** only). Avoids duplicating resolve steps across workflows.
 
 ### compile-nvhpc-cuda-mpich.yml — CUDA toolchain (compile-only)
 
@@ -200,6 +231,10 @@ GitHub Actions runs bash with `set -e -o pipefail`:
 ## Cross-Repo Testing
 
 Workflows accept `mpas-repository` and `mpas-ref` inputs for testing upstream MPAS-Dev commits. The `checkout-mpas-source` action handles the two-step checkout and CI overlay. See `.github/docs/testing-upstream-commits.md`.
+
+## Maintainer cadence
+
+On **container image tag bumps** in `ci-config.env` or **quarterly**, skim thin caller workflows under `.github/workflows/` (names starting with `test-`), confirm comments still match behavior, and manually dispatch at least one **GPU** workflow (`test-gpu-*`) if CIRRUS is available. Update [docs/ci-workflow-map.md](../docs/ci-workflow-map.md) when adding callers or reusable workflows.
 
 ## Security
 

--- a/.github/workflows/_resolve-nvhpc-containers.yml
+++ b/.github/workflows/_resolve-nvhpc-containers.yml
@@ -1,0 +1,45 @@
+# Reusable: resolve NVHPC container image names (CPU + CUDA) from ci-config.env.
+# Used by GPU ECT and NVHPC+CUDA compile-only workflows to avoid duplicating
+# resolve-container steps.
+
+name: _resolve-nvhpc-containers
+
+on:
+  workflow_call:
+    inputs:
+      mpi:
+        description: MPI implementation (mpich, openmpi)
+        required: true
+        type: string
+    outputs:
+      image_cpu:
+        description: NVHPC CPU container (CONTAINER_IMAGE template)
+        value: ${{ jobs.resolve.outputs.image_cpu }}
+      image_gpu:
+        description: NVHPC + CUDA container (CONTAINER_IMAGE_GPU template)
+        value: ${{ jobs.resolve.outputs.image_gpu }}
+
+jobs:
+  resolve:
+    name: Resolve NVHPC containers
+    runs-on: ubuntu-latest
+    outputs:
+      image_cpu: ${{ steps.cpu.outputs.image }}
+      image_gpu: ${{ steps.gpu.outputs.image }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github
+
+      - uses: ./.github/actions/resolve-container
+        id: cpu
+        with:
+          compiler: nvhpc
+          mpi: ${{ inputs.mpi }}
+
+      - uses: ./.github/actions/resolve-container
+        id: gpu
+        with:
+          compiler: nvhpc
+          mpi: ${{ inputs.mpi }}
+          gpu: cuda

--- a/.github/workflows/_test-gpu.yml
+++ b/.github/workflows/_test-gpu.yml
@@ -1,5 +1,6 @@
 # Reusable workflow: GPU (CUDA) validation via ECT (NVHPC).
 # Called by test-gpu-mpich.yml and test-gpu-openmpi.yml.
+# NVHPC images: reusable workflow _resolve-nvhpc-containers.yml (inputs.mpi).
 #
 # Builds MPAS-A with OpenACC/CUDA on CIRRUS self-hosted runners, then
 # validates via ECT (PyCECT) — the same statistical test used for CPU
@@ -33,25 +34,9 @@ on:
 jobs:
   config:
     name: Resolve Config
-    runs-on: ubuntu-latest
-    outputs:
-      image: ${{ steps.container.outputs.image }}
-      image-gpu: ${{ steps.gpu-container.outputs.image }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/resolve-container
-        id: container
-        with:
-          compiler: nvhpc
-          mpi: ${{ inputs.mpi }}
-      - uses: ./.github/actions/resolve-container
-        id: gpu-container
-        with:
-          compiler: nvhpc
-          mpi: ${{ inputs.mpi }}
-          gpu: cuda
+    uses: ./.github/workflows/_resolve-nvhpc-containers.yml
+    with:
+      mpi: ${{ inputs.mpi }}
 
   build:
     needs: config
@@ -59,7 +44,7 @@ jobs:
     runs-on:
       group: CIRRUS-4x8-gpu
     container:
-      image: ${{ needs.config.outputs.image-gpu }}
+      image: ${{ needs.config.outputs.image_gpu }}
 
     steps:
       - uses: actions/checkout@v5
@@ -116,7 +101,7 @@ jobs:
     runs-on:
       group: CIRRUS-4x8-gpu
     container:
-      image: ${{ needs.config.outputs.image-gpu }}
+      image: ${{ needs.config.outputs.image_gpu }}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/compile-nvhpc-cuda-mpich.yml
+++ b/.github/workflows/compile-nvhpc-cuda-mpich.yml
@@ -1,5 +1,6 @@
 # NVHPC + MPICH + CUDA: compile-only on GitHub-hosted runners.
 # Validates the OpenACC/CUDA toolchain (no GPU present; no model run).
+# Container names: reusable workflow _resolve-nvhpc-containers.yml (mpi=mpich).
 
 name: "NVHPC+MPICH+CUDA (compile-only)"
 
@@ -16,26 +17,16 @@ on:
 jobs:
   config:
     name: Resolve CUDA container
-    runs-on: ubuntu-latest
-    outputs:
-      image: ${{ steps.gpu.outputs.image }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          sparse-checkout: .github
-      - uses: ./.github/actions/resolve-container
-        id: gpu
-        with:
-          compiler: nvhpc
-          mpi: mpich
-          gpu: cuda
+    uses: ./.github/workflows/_resolve-nvhpc-containers.yml
+    with:
+      mpi: mpich
 
   compile:
     needs: config
     name: Compile (OpenACC, MPICH)
     runs-on: ubuntu-latest
     container:
-      image: ${{ needs.config.outputs.image }}
+      image: ${{ needs.config.outputs.image_gpu }}
 
     steps:
       - uses: actions/checkout@v5
@@ -55,4 +46,4 @@ jobs:
         shell: bash
         run: |
           echo "## NVHPC + MPICH + CUDA compile-only" >> "$GITHUB_STEP_SUMMARY"
-          echo "Built \`atmosphere_model\` with OpenACC in ${{ needs.config.outputs.image }}." >> "$GITHUB_STEP_SUMMARY"
+          echo "Built \`atmosphere_model\` with OpenACC in ${{ needs.config.outputs.image_gpu }}." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ci-template-notes.md
+++ b/docs/ci-template-notes.md
@@ -20,7 +20,8 @@ This document describes what is **MPAS-specific** versus **portable** when copyi
 
 - **Container registry**: images matching `ci-config.env` templates (e.g. `ncarcisl/hpcdev-x86_64` tags), or change templates to your registry.
 - **Self-hosted runners**: GPU workflows reference `CIRRUS-4x8-gpu` (or your org’s runner group). Update `runs-on:` to match.
-- **GitHub Actions permissions**: workflows use `contents: read`; artifact upload may need `actions: write` where used.
+- **GitHub Actions permissions**: workflows generally use `contents: read`; artifact upload itself does not require `actions: write`.
+  Use elevated permissions only for specific operations, such as deleting artifacts via `gh api` (`actions: write`) or publishing releases (`contents: write`).
 
 ## Minimal fork checklist
 

--- a/docs/ci-template-notes.md
+++ b/docs/ci-template-notes.md
@@ -1,0 +1,34 @@
+# Adapting this CI layout for other NCAR projects
+
+This document describes what is **MPAS-specific** versus **portable** when copying patterns from `NCAR/MPAS-Model-CI`.
+
+## Portable patterns
+
+- **Central env file** (here: `.github/ci-config.env`) — single source for image templates, release asset tags, and MPI flags. Forks should rename variables only if semantics change.
+- **`resolve-container` composite** — maps `(compiler, mpi, optional gpu)` to a Docker image string from templates.
+- **Thin caller workflows** — `on:` + `jobs: { call: reusable with inputs }`. Add a new subset by copying one caller and changing inputs.
+- **Reusable workflows** — `_test-compiler.yml`-style templates for “build + test + report” pipelines.
+- **`_resolve-nvhpc-containers.yml`** — shared NVHPC CPU + CUDA image resolution for any workflow that needs both strings.
+
+## MPAS-specific pieces (replace when porting)
+
+- **`build-mpas`**, **`run-mpas`**, **`run-perturb-mpas`**, **`validate-ect`** — assume MPAS-A layout, `atmosphere_model`, namelist/streams, ECT/PyCECT.
+- **Test data** — GitHub releases on this repo (`testdata-*`, `ect-*`). Another model would use its own release layout and env variable names.
+- **BFB scripts** — `compare-bfb-nc.py`, single-precision 240km assumptions.
+
+## Infrastructure you must supply
+
+- **Container registry**: images matching `ci-config.env` templates (e.g. `ncarcisl/hpcdev-x86_64` tags), or change templates to your registry.
+- **Self-hosted runners**: GPU workflows reference `CIRRUS-4x8-gpu` (or your org’s runner group). Update `runs-on:` to match.
+- **GitHub Actions permissions**: workflows use `contents: read`; artifact upload may need `actions: write` where used.
+
+## Minimal fork checklist
+
+1. Copy `.github/ci-config.env`, `resolve-container`, and any composite actions you need.
+2. Replace container templates and `MAKE_TARGET_*` / compiler mappings for your build system.
+3. Replace or stub `build-mpas` with your model’s build steps.
+4. Point `download-testdata` (or equivalent) at your release assets and env tags.
+5. Rename workflows and badges in `README.md`; keep caller → reusable structure.
+6. Run a **CPU subset** on GitHub-hosted `ubuntu-latest` before relying on self-hosted GPU runners.
+
+For the full workflow inventory, see [ci-workflow-map.md](ci-workflow-map.md).

--- a/docs/ci-template-notes.md
+++ b/docs/ci-template-notes.md
@@ -12,9 +12,8 @@ This document describes what is **MPAS-specific** versus **portable** when copyi
 
 ## MPAS-specific pieces (replace when porting)
 
-- **`build-mpas`**, **`run-mpas`**, **`run-perturb-mpas`**, **`validate-ect`** — assume MPAS-A layout, `atmosphere_model`, namelist/streams, ECT/PyCECT.
-- **Test data** — GitHub releases on this repo (`testdata-*`, `ect-*`). Another model would use its own release layout and env variable names.
-- **BFB scripts** — `compare-bfb-nc.py`, single-precision 240km assumptions.
+- **`build-mpas`**, **`run-mpas`**, **`run-perturb-mpas`**, **`validate-ect`** — assume MPAS-A layout, `atmosphere_model`, namelist/streams, ECT/PyCECT
+
 
 ## Infrastructure you must supply
 

--- a/docs/ci-workflow-map.md
+++ b/docs/ci-workflow-map.md
@@ -1,0 +1,46 @@
+# CI workflow map (MPAS-Model-CI)
+
+Maintainer reference: how workflows connect and where logic lives. For a shorter overview, see [AGENT_GUIDE.md](../.github/AGENT_GUIDE.md).
+
+## Reusable workflows (`workflow_call`)
+
+| Workflow | Purpose | Called by |
+|----------|---------|-----------|
+| `_test-compiler.yml` | CPU build + ECT | `test-{gcc,intel,nvhpc}-{mpich,openmpi}.yml` (subset callers) |
+| `_test-gpu.yml` | NVHPC OpenACC build + ECT on CIRRUS | `test-gpu-mpich.yml`, `test-gpu-openmpi.yml` |
+| `_test-bfb.yml` | Bit-for-bit variants | `bfb-io.yml`, `bfb-decomp.yml` |
+| `_resolve-nvhpc-containers.yml` | Resolve NVHPC CPU + CUDA images from `ci-config.env` | `_test-gpu.yml`, `compile-nvhpc-cuda-mpich.yml` |
+
+## Caller workflows (thin entry points)
+
+| Caller | Trigger | Invokes |
+|--------|---------|---------|
+| `test-*-mpich.yml` | push/PR `master`, `develop` | `_test-compiler` |
+| `test-*-openmpi.yml` | `workflow_dispatch` | `_test-compiler` |
+| `test-gpu-*.yml` | `workflow_dispatch` | `_test-gpu` |
+| `compile-nvhpc-cuda-mpich.yml` | push/PR + dispatch | `_resolve-nvhpc-containers` (then compile job) |
+| `coverage.yml` | push `master` | (standalone) |
+| `unit-tests.yml` | push/PR | (standalone) |
+| `ect-test.yml`, `ect-ensemble-gen.yml` | dispatch / manual | (standalone) |
+| `profile-gpu-nsight.yml` | `workflow_dispatch` | stub on `master` until full CIRRUS workflow merges |
+
+## Composite actions (shared steps)
+
+| Action | Role |
+|--------|------|
+| `resolve-container` | Image string from `ci-config.env` |
+| `build-mpas` | Make MPAS-A |
+| `download-testdata` | Release asset → case dir |
+| `run-mpas` / `run-perturb-mpas` | Model runs |
+| `validate-ect` | PyCECT |
+| `checkout-mpas-source` | Cross-repo + CI overlay |
+
+## Duplication addressed in this refactor
+
+- **NVHPC container resolution** (CPU + CUDA image names) was repeated in `_test-gpu.yml` `config` job and `compile-nvhpc-cuda-mpich.yml`. Centralized in **`_resolve-nvhpc-containers.yml`**.
+
+## Extension points
+
+- New **CPU subset**: add `test-<compiler>-<mpi>.yml` calling `_test-compiler` with `compiler` / `mpi` inputs.
+- New **GPU ECT subset**: add `test-gpu-<mpi>.yml` calling `_test-gpu` with `mpi`.
+- Container tags / mappings: edit **`.github/ci-config.env`** only; avoid hardcoding image names in YAML.


### PR DESCRIPTION
## Summary

Implements the **feature-ci-cleanup** plan: clearer modular boundaries, documentation for students/scientists/engineers, and a lightweight template story for other NCAR projects.

## Code

- **New** [\_resolve-nvhpc-containers.yml\](.github/workflows/_resolve-nvhpc-containers.yml): reusable \workflow_call\ that resolves NVHPC CPU + CUDA container image strings from [\ci-config.env\](.github/ci-config.env) (same two \esolve-container\ steps as before).
- **Refactor** [\_test-gpu.yml\](.github/workflows/_test-gpu.yml) and [\compile-nvhpc-cuda-mpich.yml\](.github/workflows/compile-nvhpc-cuda-mpich.yml) to call it; downstream jobs use \
eeds.config.outputs.image_gpu\ (underscore; replaces \image-gpu\).
- Short header comments on the touched workflows.

## Docs

- [\docs/ci-workflow-map.md\](docs/ci-workflow-map.md): caller vs reusable vs composite inventory and extension points.
- [\docs/ci-template-notes.md\](docs/ci-template-notes.md): what is portable vs MPAS-specific when forking CI.
- [\AGENT_GUIDE.md\](.github/AGENT_GUIDE.md): **Who this guide is for**, repository layout (including \docs/\), workflow **mermaid** graph, **\_resolve-nvhpc-containers\** section, **maintainer cadence**.

## Notes

- **Independent of** \eature-ci-nsys\ (Nsight profiling merges when \
sys\ is healthy on the image/runner).



Made with [Cursor](https://cursor.com)