### PR TITLE
BFB: MPI decomposition on GPU (CIRRUS)

### DIFF
--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -136,9 +136,9 @@ The reusable workflow `_test-bfb.yml` takes a **`variants`** input: a JSON **arr
 
 Variants that share the same `use_pio` value reuse one compiled executable. The variant at **`reference_index`** (default **0**) is the reference; every other variant’s history file is compared to it (variable data, not raw file bytes — see `.github/scripts/compare-bfb-nc.py`).
 
-**GPU BFB:** set workflow input **`gpu: 'true'`** (string). `_test-bfb.yml` then resolves **`CONTAINER_IMAGE_GPU`**, builds with **`openacc: true`**, and runs build/run jobs on **`CIRRUS-4x8-gpu`**. **`compiler` must be `nvhpc`**. Precision is typically **`double`** to match `_test-gpu.yml`. Example caller: **`bfb-decomp-gpu.yml`** (1 vs 4 ranks, decomposition BFB on GPU). Do **not** add `pull_request` triggers for GPU BFB — same policy as `_test-gpu.yml`.
+**GPU BFB:** set workflow input **`gpu: 'true'`** (string). `_test-bfb.yml` then resolves **`CONTAINER_IMAGE_GPU`**, builds with **`openacc: true`**, and runs build/run jobs on **`CIRRUS-4x8-gpu`**. **`compiler` must be `nvhpc`**. Precision is typically **`double`** to match `_test-gpu.yml`. Example callers: **`bfb-decomp-gpu.yml`** (1 vs 4 ranks), **`bfb-io-gpu.yml`** (SMIOL vs PIO, 4 ranks). Do **not** add `pull_request` triggers for GPU BFB — same policy as `_test-gpu.yml`.
 
-**Adding a new BFB test:** copy `bfb-io.yml`, `bfb-decomp.yml`, or `bfb-decomp-gpu.yml`, set `name` and `on`, and edit **`variants`** (and `gpu` / `precision` when applicable). MPI rank count and PIO vs SMIOL are common examples only; any future per-run knob exposed on `variants` and implemented in `_test-bfb.yml` / composite actions can be combined the same way.
+**Adding a new BFB test:** copy `bfb-io.yml`, `bfb-decomp.yml`, `bfb-io-gpu.yml`, or `bfb-decomp-gpu.yml`, set `name` and `on`, and edit **`variants`** (and `gpu` / `precision` when applicable). MPI rank count and PIO vs SMIOL are common examples only; any future per-run knob exposed on `variants` and implemented in `_test-bfb.yml` / composite actions can be combined the same way.
 
 ## Container Environment
 

--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -136,7 +136,9 @@ The reusable workflow `_test-bfb.yml` takes a **`variants`** input: a JSON **arr
 
 Variants that share the same `use_pio` value reuse one compiled executable. The variant at **`reference_index`** (default **0**) is the reference; every other variant’s history file is compared to it (variable data, not raw file bytes — see `.github/scripts/compare-bfb-nc.py`).
 
-**Adding a new BFB test:** copy `bfb-io.yml` or `bfb-decomp.yml`, set `name` and `on`, and edit **`variants`**. MPI rank count and PIO vs SMIOL are common examples only; any future per-run knob exposed on `variants` and implemented in `_test-bfb.yml` / composite actions can be combined the same way.
+**GPU BFB:** set workflow input **`gpu: 'true'`** (string). `_test-bfb.yml` then resolves **`CONTAINER_IMAGE_GPU`**, builds with **`openacc: true`**, and runs build/run jobs on **`CIRRUS-4x8-gpu`**. **`compiler` must be `nvhpc`**. Precision is typically **`double`** to match `_test-gpu.yml`. Example caller: **`bfb-decomp-gpu.yml`** (1 vs 4 ranks, decomposition BFB on GPU). Do **not** add `pull_request` triggers for GPU BFB — same policy as `_test-gpu.yml`.
+
+**Adding a new BFB test:** copy `bfb-io.yml`, `bfb-decomp.yml`, or `bfb-decomp-gpu.yml`, set `name` and `on`, and edit **`variants`** (and `gpu` / `precision` when applicable). MPI rank count and PIO vs SMIOL are common examples only; any future per-run knob exposed on `variants` and implemented in `_test-bfb.yml` / composite actions can be combined the same way.
 
 ## Container Environment
 

--- a/.github/workflows/_test-bfb.yml
+++ b/.github/workflows/_test-bfb.yml
@@ -4,6 +4,8 @@
 # produce bitwise-identical history variable data. The first variant (or
 # reference_index) is the reference; every other variant is compared against it.
 #
+# Optional input `gpu: 'true'`: CUDA container, OpenACC build, CIRRUS runners (nvhpc only).
+#
 # MPI rank count and PIO vs SMIOL are common dimensions but not special — add any
 # new scenario by appending another variant object (and a small caller workflow).
 
@@ -56,6 +58,11 @@ on:
         required: false
         type: number
         default: 0
+      gpu:
+        description: 'If true, CUDA image + OpenACC build + CIRRUS GPU runners (requires compiler nvhpc). Same security model as _test-gpu — use workflow_dispatch only.'
+        required: false
+        type: string
+        default: 'false'
 
 jobs:
   config:
@@ -70,11 +77,22 @@ jobs:
         with:
           sparse-checkout: .github
 
+      - name: Validate GPU BFB inputs
+        if: ${{ inputs.gpu == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.compiler }}" != "nvhpc" ]; then
+            echo "::error::gpu=true requires compiler=nvhpc (got ${{ inputs.compiler }})"
+            exit 1
+          fi
+
       - uses: ./.github/actions/resolve-container
         id: container
         with:
           compiler: ${{ inputs.compiler }}
           mpi: ${{ inputs.mpi }}
+          gpu: ${{ inputs.gpu == 'true' && 'cuda' || '' }}
 
       - name: Parse variants
         id: variants
@@ -125,7 +143,7 @@ jobs:
       matrix:
         build_tag: ${{ fromJSON(needs.config.outputs.build_tags) }}
     name: Build (${{ matrix.build_tag }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.gpu == 'true' && fromJSON('{"group":"CIRRUS-4x8-gpu"}') || 'ubuntu-latest' }}
     container:
       image: ${{ needs.config.outputs.image }}
     steps:
@@ -138,6 +156,7 @@ jobs:
         with:
           compiler: ${{ inputs.compiler }}
           use-pio: ${{ matrix.build_tag == 'pio' && 'true' || 'false' }}
+          openacc: ${{ inputs.gpu == 'true' && 'true' || 'false' }}
           precision: ${{ inputs.precision }}
 
       - name: Upload executable
@@ -154,7 +173,7 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.config.outputs.run_variants) }}
     name: Run (${{ matrix.id }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.gpu == 'true' && fromJSON('{"group":"CIRRUS-4x8-gpu"}') || 'ubuntu-latest' }}
     container:
       image: ${{ needs.config.outputs.image }}
     steps:
@@ -164,6 +183,12 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: exe-bfb-${{ matrix.build_tag }}
+
+      - name: Check GPU availability
+        if: ${{ inputs.gpu == 'true' }}
+        run: |
+          echo "=== GPU Information ==="
+          nvidia-smi || echo "WARNING: nvidia-smi failed"
 
       - name: Run MPAS-A
         uses: ./.github/actions/run-mpas

--- a/.github/workflows/bfb-decomp-gpu.yml
+++ b/.github/workflows/bfb-decomp-gpu.yml
@@ -1,0 +1,20 @@
+# BFB on GPU: same OpenACC/CUDA build, different MPI rank counts (decomposition).
+# CIRRUS self-hosted runners — trigger via workflow_dispatch only (see _test-gpu.yml).
+
+name: "BFB: Decomposition GPU (1 vs 4 ranks)"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: ./.github/workflows/_test-bfb.yml
+    with:
+      compiler: nvhpc
+      mpi: mpich
+      gpu: 'true'
+      precision: double
+      run-timeout: '20'
+      variants: >-
+        [{"id":"r1","ranks":1,"label":"1 rank"},
+         {"id":"r4","ranks":4,"label":"4 ranks"}]

--- a/.github/workflows/bfb-io-gpu.yml
+++ b/.github/workflows/bfb-io-gpu.yml
@@ -1,0 +1,20 @@
+# BFB on GPU: two I/O builds (SMIOL vs PIO), same MPI rank count.
+# CIRRUS self-hosted runners — trigger via workflow_dispatch only (see _test-gpu.yml).
+
+name: "BFB: I/O GPU (SMIOL vs PIO)"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: ./.github/workflows/_test-bfb.yml
+    with:
+      compiler: nvhpc
+      mpi: mpich
+      gpu: 'true'
+      precision: double
+      run-timeout: '20'
+      variants: >-
+        [{"id":"smiol-r4","ranks":4,"label":"SMIOL, 4 ranks"},
+         {"id":"pio-r4","use_pio":true,"ranks":4,"label":"PIO, 4 ranks"}]

--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ Thanks to Teo Price-Broncucia and Allison Baker for their help on ensemble consi
 
 ### Additional testing 
 
-Bit-for-bit (BFB) workflows compare history output in single precision (240km case; see the BFB section in [`.github/ci-config.env`](.github/ci-config.env)). They run on manual dispatch.
+Bit-for-bit (BFB) workflows compare history output in single precision for CPU runs (240km case; see the BFB section in [`.github/ci-config.env`](.github/ci-config.env)). They run on manual dispatch (and some callers also run on push to `feature-ci-bfb`). **BFB: Decomposition (GPU)** uses NVHPC + CUDA + OpenACC, double precision, CIRRUS runners, and only `workflow_dispatch` — same policy as the GPU ECT subset.
 
 | Test | Status |
 |------|--------|
 | BFB: I/O (SMIOL vs PIO) | [![BFB: I/O (SMIOL vs PIO)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-io.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-io.yml) |
 | BFB: Decomposition (1 vs 4 ranks) | [![BFB: Decomposition (1 vs 4 ranks)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp.yml) |
+| BFB: Decomposition GPU (1 vs 4 ranks) | [![BFB: Decomposition GPU (1 vs 4 ranks)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp-gpu.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp-gpu.yml) |
 | Code coverage | [![Code Coverage](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/coverage.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/coverage.yml) [![codecov](https://codecov.io/gh/NCAR/MPAS-Model-CI/graph/badge.svg)](https://codecov.io/gh/NCAR/MPAS-Model-CI) |
 
 Container images are from [ncarcisl/hpcdev](https://hub.docker.com/r/ncarcisl/hpcdev-x86_64).

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Thanks to Teo Price-Broncucia and Allison Baker for their help on ensemble consi
 | Intel | MPICH | CPU | [![Intel+MPICH (CPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-intel-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-intel-mpich.yml) | `hpcdev:leap-oneapi-mpich-25.09`\* |
 | Intel | OpenMPI | CPU | [![Intel+OpenMPI (CPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-intel-openmpi.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-intel-openmpi.yml) | `hpcdev:leap-oneapi-openmpi-25.09`\* |
 | NVHPC | MPICH | CPU | [![NVHPC+MPICH (CPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-nvhpc-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-nvhpc-mpich.yml) | `hpcdev:almalinux9-nvhpc-mpich-26.02` |
-| NVHPC | OpenMPI | CPU | [![NVHPC+OpenMPI (CPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-nvhpc-openmpi.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-nvhpc-openmpi.yml) | `hpcdev:almalinux9-nvhpc-openmpi-26.02` |
+| NVHPC | OpenMPI | CPU | [![NVHPC+OpenMPI (CPU)](https://img.shields.io/badge/NVHPC%2BOpenMPI%20(CPU)-no%20data-lightgrey)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-nvhpc-openmpi.yml) | `hpcdev:almalinux9-nvhpc-openmpi-26.02` |
 | NVHPC | MPICH | GPU | [![NVHPC+MPICH (GPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-mpich.yml) | `hpcdev:almalinux9-nvhpc-mpich-cuda-26.02` |
-| NVHPC | OpenMPI | GPU | [![NVHPC+OpenMPI (GPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-openmpi.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-openmpi.yml) | `hpcdev:almalinux9-nvhpc-openmpi-cuda-26.02` |
+| NVHPC | OpenMPI | GPU | [![NVHPC+OpenMPI (GPU)](https://img.shields.io/badge/NVHPC%2BOpenMPI%20(GPU)-no%20data-lightgrey)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-openmpi.yml) | `hpcdev:almalinux9-nvhpc-openmpi-cuda-26.02` |
 
-\* Intel pinned to `hpcdev 25.09` (IFX 2025.2) to avoid an IFX 2025.3 preprocessor regression. This issue has been addressed by [MPAS-Dev:develop #1392](https://github.com/MPAS-Dev/MPAS-Model/pull/1392) 
+\* Intel pinned to `hpcdev 25.09` (IFX 2025.2) to avoid an IFX 2025.3 preprocessor regression. This issue has been addressed by [MPAS-Dev:develop #1392](https://github.com/MPAS-Dev/MPAS-Model/pull/1392)
+
+† **NVHPC+OpenMPI** rows use a static grey “no data” badge instead of the live Actions badge so the README does not show a red failure from a suspected OpenMPI runtime regression; workflows remain available via manual dispatch. See [AGENT_GUIDE.md](.github/AGENT_GUIDE.md) (NVHPC+OpenMPI).
 
 **Compile-only** workflows verify the NVHPC + OpenACC + CUDA toolchain by building on a Github Action runner without a GPU
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ Thanks to Teo Price-Broncucia and Allison Baker for their help on ensemble consi
 
 ### Additional testing 
 
-Bit-for-bit (BFB) workflows compare history output in single precision for CPU runs (240km case; see the BFB section in [`.github/ci-config.env`](.github/ci-config.env)). They run on manual dispatch (and some callers also run on push to `feature-ci-bfb`). **BFB: Decomposition (GPU)** uses NVHPC + CUDA + OpenACC, double precision, CIRRUS runners, and only `workflow_dispatch` — same policy as the GPU ECT subset.
+Bit-for-bit (BFB) workflows compare history output in single precision for CPU runs (240km case; see the BFB section in [`.github/ci-config.env`](.github/ci-config.env)). They run on manual dispatch (and some callers also run on push to `feature-ci-bfb`). **GPU BFB** workflows (`bfb-io-gpu`, `bfb-decomp-gpu`) use NVHPC + CUDA + OpenACC, double precision, CIRRUS runners, and only `workflow_dispatch` — same policy as the GPU ECT subset.
 
 | Test | Status |
 |------|--------|
 | BFB: I/O (SMIOL vs PIO) | [![BFB: I/O (SMIOL vs PIO)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-io.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-io.yml) |
 | BFB: Decomposition (1 vs 4 ranks) | [![BFB: Decomposition (1 vs 4 ranks)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp.yml) |
+| BFB: I/O GPU (SMIOL vs PIO) | [![BFB: I/O GPU (SMIOL vs PIO)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-io-gpu.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-io-gpu.yml) |
 | BFB: Decomposition GPU (1 vs 4 ranks) | [![BFB: Decomposition GPU (1 vs 4 ranks)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp-gpu.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp-gpu.yml) |
 | Code coverage | [![Code Coverage](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/coverage.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/coverage.yml) [![codecov](https://codecov.io/gh/NCAR/MPAS-Model-CI/graph/badge.svg)](https://codecov.io/gh/NCAR/MPAS-Model-CI) |
 


### PR DESCRIPTION
## Summary

Adds a **bit-for-bit decomposition test on GPU**: same OpenACC/CUDA build, **1 vs 4 MPI ranks**, history comparison via existing _test-bfb + compare-bfb-nc.py.

## Changes

- **_test-bfb.yml**: New optional input **gpu: 'true'** — resolves **CONTAINER_IMAGE_GPU**, enables **OpenACC** in uild-mpas, runs **build/run** on **CIRRUS-4x8-gpu**, validates **compiler: nvhpc**, optional 
vidia-smi on run jobs.
- **fb-decomp-gpu.yml**: Caller mirroring **fb-decomp.yml** but NVHPC + MPICH + **gpu: 'true'**, **precision: double**, **un-timeout: '20'**, **workflow_dispatch only** (same security model as GPU ECT).
- **README** + **AGENT_GUIDE**: Document GPU BFB and badge.

## Notes

First run on CIRRUS may reveal whether MPI decomposition is BFB for OpenACC on this case; if not, the workflow still gives a clear compare failure for investigation.