### PR TITLE
CI: GPU dispatch-only, Intel unpin, docs cleanup

### DIFF
--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -117,7 +117,7 @@ All container images, compiler mappings, MPI flags, per-asset release tags, ECT 
 
 Key settings:
 - `CONTAINER_IMAGE` / `CONTAINER_IMAGE_GPU` — image templates with `{compiler}` and `{mpi}` placeholders
-- `CONTAINER_IMAGE_{compiler}` — per-compiler overrides (Intel pinned to `hpcdev 25.09`)
+- `CONTAINER_IMAGE_{compiler}` — optional per-compiler image template overrides
 - `CONTAINER_COMPILER_{name}` — name mappings when image tags differ (e.g., `gcc` → `gcc14`)
 - `MAKE_TARGET_{compiler}` — maps CI names to Makefile targets
 - `NVHPC_EXTRA_MAKE_FLAGS` / `ONEAPI_EXTRA_MAKE_FLAGS` — compiler-specific build workarounds
@@ -152,8 +152,7 @@ Variants that share the same `use_pio` value reuse one compiled executable. The 
 All builds and runs use `ncarcisl/hpcdev-x86_64` Docker containers. Image names are resolved from `ci-config.env` templates.
 
 Current containers:
-- **GCC, NVHPC**: `hpcdev-x86_64:almalinux9-{compiler}-{mpi}-26.02`
-- **Intel**: `hpcdev-x86_64:leap-oneapi-{mpi}-25.09` (pinned to avoid IFX 2025.3 fpp regression)
+- **GCC, NVHPC, Intel (OneAPI)**: `hpcdev-x86_64:almalinux9-{compiler}-{mpi}-26.02` (`CONTAINER_COMPILER_*` mappings apply, e.g. `gcc` → `gcc14`)
 - **GPU**: `hpcdev-x86_64:almalinux9-nvhpc-{mpi}-cuda-26.02`
 
 Container facts:
@@ -221,6 +220,5 @@ Workflows accept `mpas-repository` and `mpas-ref` inputs for testing upstream MP
 
 ## Known Issues
 
-- **IFX 2025.3 fpp regression**: breaks `#define COMMA ,` pattern in 6+ framework files. Intel pinned to hpcdev 25.09 (IFX 2025.2.1). Remove override when IFX 2025.4+ is available.
 - **NVHPC+OpenMPI**: model exits 134 (SIGABRT) on GA runners with 4 ranks. MPICH works. Caller workflows and reusable CPU/GPU jobs mark this combination `continue-on-error` until resolved.
 - **NVHPC/Intel MPI F08 bindings**: broken with hpcdev MPI libraries. Both use `MPAS_MPI_F08=0` workaround.

--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -67,7 +67,7 @@ Current tags: `testdata-240km-v1`, `testdata-120km-v1`, `ect-summary-v1`, `ect-r
 
 - **`master`** — default branch, mirrors upstream MPAS-Model. Workflow files must exist here for the `workflow_dispatch` UI button to appear.
 - **`develop`** — upstream develop branch.
-- **Topic branches** — fork from `master` for changes. Branches named **`hackathon-*`** (e.g. `hackathon-team-a`) auto-run **CPU ECT subsets** (push/PR) and **GPU ECT subsets** (push and in-repo PR; fork PRs skip GPU — see Security). CPU BFB callers also run on push to `hackathon`, `hackathon/**`, `hackathon-*`, or legacy `feature-ci-bfb`.
+- **Topic branches** — fork from `master` for changes. Branches named **`hackathon-*`** auto-run **CPU ECT subsets** (push/PR). **GPU ECT** stays **`workflow_dispatch` only** (see Security). CPU BFB callers also run on push to `hackathon`, `hackathon/**`, `hackathon-*`, or legacy `feature-ci-bfb`.
 
 ## Workflow Architecture
 
@@ -81,7 +81,7 @@ Each compiler+MPI combination has a thin caller workflow that invokes a reusable
 **MPICH callers** (`test-gcc-mpich`, `test-intel-mpich`, `test-nvhpc-mpich`) run on push/PR to `master`/`develop` and to **`hackathon-*`**.
 **compile-nvhpc-cuda-mpich** (NVHPC + OpenACC compile-only on GitHub-hosted runners) also runs on push/PR to those branches.
 **OpenMPI CPU callers** (`test-*-openmpi`) stay **`workflow_dispatch` only** (optional; OpenMPI regressions).
-**GPU ECT callers** (`test-gpu-mpich`, `test-gpu-openmpi`) run on **`push` and `pull_request` to `hackathon-*`** (PR job skipped for **fork** heads) and on `workflow_dispatch`.
+**GPU ECT callers** (`test-gpu-mpich`, `test-gpu-openmpi`) are **`workflow_dispatch` only** (self-hosted CIRRUS).
 
 ### _test-compiler.yml — Reusable CPU Workflow
 
@@ -215,7 +215,7 @@ Workflows accept `mpas-repository` and `mpas-ref` inputs for testing upstream MP
 
 ## Security
 
-- **Self-hosted runners**: GPU ECT workflows (`_test-gpu`, `test-gpu-*`) may use `pull_request` to **`hackathon-*`** only with a **non-fork guard** on the job (`pull_request.head.repo.fork == false`). **`push` to `hackathon-*`** is allowed for trusted writers. Do **not** run GPU ECT on `pull_request` to `master`/`develop` from forks. **`profile-gpu-nsight`** stays `workflow_dispatch` only.
+- **Self-hosted runners**: GPU ECT workflows (`_test-gpu`, `test-gpu-*`) use **`workflow_dispatch` only**. Do **not** add `push` or `pull_request` triggers — unreviewed code could run on CIRRUS. **`profile-gpu-nsight`** is also `workflow_dispatch` only.
 - **Secret isolation**: Test data is public release assets on this repo, so CI does not need a separate data-repo PAT for downloads.
 - **Cross-repo execution**: `workflow_dispatch` with external repo inputs runs `make` from that repo. Acceptable since only write-access users can trigger it.
 

--- a/.github/ci-config.env
+++ b/.github/ci-config.env
@@ -123,4 +123,6 @@ NSYS_CLI_CACHE_VERSION=1
 
 
 # ── KNOWN ISSUES ─────────────────────────────────
-# See AGENT_GUIDE.md (NVHPC+OpenMPI, MPI F08 workaround, etc.).
+# NVHPC+OpenMPI ECT may fail on GitHub-hosted runners (SIGABRT); subset
+# workflows use continue-on-error for that combination.
+# NVHPC and OneAPI builds set MPAS_MPI_F08=0 (see ONEAPI/NVHPC extra flags above).

--- a/.github/ci-config.env
+++ b/.github/ci-config.env
@@ -20,10 +20,7 @@ CONTAINER_IMAGE_GPU="docker.io/ncarcisl/hpcdev-x86_64:almalinux9-{compiler}-{mpi
 
 # Per-compiler image overrides (optional).
 # Format: CONTAINER_IMAGE_{compiler}="template"
-# Intel is pinned to hpcdev 25.09 (IFX 2025.2) to avoid a
-# preprocessor regression in IFX 2025.3 (see KNOWN ISSUES below).
-CONTAINER_IMAGE_oneapi="docker.io/ncarcisl/hpcdev-x86_64:leap-{compiler}-{mpi}-25.09"
-
+# Intel (oneapi) uses the default CONTAINER_IMAGE template (almalinux9-oneapi-{mpi}-26.02).
 
 # ── Compiler / MPI name mappings ─────────────────
 # Workflows use short family names (gcc, nvhpc, oneapi) for the
@@ -127,10 +124,4 @@ NSYS_CLI_CACHE_VERSION=1
 
 
 # ── KNOWN ISSUES ─────────────────────────────────
-#
-# IFX 2025.3 preprocessor regression
-#   fpp expands nested macro arguments before evaluating the outer macro's
-#   argument count, breaking MPAS's `#define COMMA ,` / DMPAR_DEBUG_WRITE()
-#   pattern in 6+ framework .F files. No viable source-level workaround.
-#   CONTAINER_IMAGE_oneapi above pins Intel to hpcdev 25.09 (IFX 2025.2.1).
-#   Remove the override when hpcdev ships IFX 2025.4+ with the fix.
+# See AGENT_GUIDE.md (NVHPC+OpenMPI, MPI F08 workaround, etc.).

--- a/.github/ci-config.env
+++ b/.github/ci-config.env
@@ -20,7 +20,6 @@ CONTAINER_IMAGE_GPU="docker.io/ncarcisl/hpcdev-x86_64:almalinux9-{compiler}-{mpi
 
 # Per-compiler image overrides (optional).
 # Format: CONTAINER_IMAGE_{compiler}="template"
-# Intel (oneapi) uses the default CONTAINER_IMAGE template (almalinux9-oneapi-{mpi}-26.02).
 
 # ── Compiler / MPI name mappings ─────────────────
 # Workflows use short family names (gcc, nvhpc, oneapi) for the

--- a/.github/docs/iss-talk-slide-outline.md
+++ b/.github/docs/iss-talk-slide-outline.md
@@ -177,7 +177,7 @@ Adding a new test case or resolution = new config directory, no workflow changes
   - CI/CD page auto-generated from actual workflow files
   - Generator script (`generate_ci_docs.py`) ensures docs never drift
     from implementation
-- **Agent Guide**: Internal reference for CI maintainers
+- **CI layout**: Workflows and composite actions under `.github/`, central config in `ci-config.env`
 - **Testing upstream commits**: Step-by-step guide for cross-repo testing
 
 ---

--- a/.github/docs/iss-talk-slide-outline.md
+++ b/.github/docs/iss-talk-slide-outline.md
@@ -177,7 +177,7 @@ Adding a new test case or resolution = new config directory, no workflow changes
   - CI/CD page auto-generated from actual workflow files
   - Generator script (`generate_ci_docs.py`) ensures docs never drift
     from implementation
-- **CI layout**: Workflows and composite actions under `.github/`, central config in `ci-config.env`
+- **CI layout**: Workflows and composite actions under `.github/`, central config in `.github/ci-config.env`
 - **Testing upstream commits**: Step-by-step guide for cross-repo testing
 
 ---

--- a/.github/workflows/_test-gpu.yml
+++ b/.github/workflows/_test-gpu.yml
@@ -5,9 +5,8 @@
 # validates via ECT (PyCECT) — the same statistical test used for CPU
 # subsets. GPU results are not expected to be bit-for-bit identical to CPU.
 #
-# Security: Runs on self-hosted CIRRUS runners. Callers use workflow_dispatch,
-# push to hackathon-*, and pull_request to hackathon-* with a non-fork guard —
-# never bare pull_request to master/develop (fork risk).
+# Security: Runs on self-hosted CIRRUS runners. Callers must use workflow_dispatch
+# only — never push or pull_request triggers (fork / unreviewed code risk on CIRRUS).
 
 name: _test-gpu
 

--- a/.github/workflows/bfb-decomp.yml
+++ b/.github/workflows/bfb-decomp.yml
@@ -1,5 +1,5 @@
 # Example BFB caller: same I/O build, different MPI rank counts (decomposition).
-# Add new scenarios by copying this file and changing `variants` (see AGENT_GUIDE.md).
+# Add new scenarios by copying this file and editing `variants` (see `_test-bfb.yml` and `.github/ci-config.env` BFB_*).
 
 name: "BFB: Decomposition (1 vs 4 ranks)"
 

--- a/.github/workflows/bfb-io.yml
+++ b/.github/workflows/bfb-io.yml
@@ -1,5 +1,5 @@
 # Example BFB caller: two I/O builds (SMIOL vs PIO), same rank count.
-# Add new scenarios by copying this file and changing `variants` (see AGENT_GUIDE.md).
+# Add new scenarios by copying this file and editing `variants` (see `_test-bfb.yml` and `.github/ci-config.env` BFB_*).
 
 name: "BFB: I/O (SMIOL vs PIO)"
 

--- a/.github/workflows/test-gpu-mpich.yml
+++ b/.github/workflows/test-gpu-mpich.yml
@@ -1,21 +1,14 @@
 # Subset CI: NVHPC + MPICH (GPU vs CPU)
 # Runs on CIRRUS self-hosted runners with GPU access.
-#
-# Auto-runs on push and on pull_request to hackathon-*. For pull_request,
-# the job is skipped when the head branch is from a fork (no unreviewed code on CIRRUS).
+# workflow_dispatch only — no push/pull_request (self-hosted security).
 
 name: "NVHPC+MPICH (GPU)"
 
 on:
   workflow_dispatch:
-  push:
-    branches: ['hackathon-*']
-  pull_request:
-    branches: ['hackathon-*']
 
 jobs:
   test:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     uses: ./.github/workflows/_test-gpu.yml
     with:
       mpi: mpich

--- a/.github/workflows/test-gpu-openmpi.yml
+++ b/.github/workflows/test-gpu-openmpi.yml
@@ -1,22 +1,15 @@
 # Subset CI: NVHPC + OpenMPI (GPU vs CPU)
 # Runs on CIRRUS self-hosted runners with GPU access.
 # Known issue: NVHPC+OpenMPI SIGABRT.
-#
-# Auto-runs on push and on pull_request to hackathon-*. For pull_request,
-# the job is skipped when the head branch is from a fork.
+# workflow_dispatch only — no push/pull_request (self-hosted security).
 
 name: "NVHPC+OpenMPI (GPU)"
 
 on:
   workflow_dispatch:
-  push:
-    branches: ['hackathon-*']
-  pull_request:
-    branches: ['hackathon-*']
 
 jobs:
   test:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     uses: ./.github/workflows/_test-gpu.yml
     with:
       mpi: openmpi

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Thanks to Teo Price-Broncucia and Allison Baker for their help on ensemble consi
 
 \* Intel pinned to `hpcdev 25.09` (IFX 2025.2) to avoid an IFX 2025.3 preprocessor regression. This issue has been addressed by [MPAS-Dev:develop #1392](https://github.com/MPAS-Dev/MPAS-Model/pull/1392)
 
-† **NVHPC+OpenMPI** ECT is fragile (suspected OpenMPI runtime issues: CPU job may exit 134 on GA runners; GPU path is `workflow_dispatch` and **`hackathon-*`** only). Badges reflect the latest workflow run — use **MPICH** subsets for routine green CI.
+† **NVHPC+OpenMPI** ECT is fragile (suspected OpenMPI runtime issues: CPU job may exit 134 on GA runners; GPU path is **`workflow_dispatch` only** on CIRRUS). Badges reflect the latest workflow run — use **MPICH** subsets for routine green CI.
 
 **Compile-only** workflows verify the NVHPC + OpenACC + CUDA toolchain by building on a Github Action runner without a GPU
 
@@ -35,7 +35,7 @@ Thanks to Teo Price-Broncucia and Allison Baker for their help on ensemble consi
 
 ### Additional testing 
 
-Bit-for-bit (BFB) workflows compare history output in single precision for CPU runs (240km case; see the BFB section in [`.github/ci-config.env`](.github/ci-config.env)). They run on **`workflow_dispatch`**, and CPU BFB callers also run on push to **`hackathon`**, **`hackathon/**`**, or legacy **`feature-ci-bfb`**. **GPU BFB** workflows (`bfb-io-gpu`, `bfb-decomp-gpu`) use NVHPC + CUDA + OpenACC, double precision, CIRRUS runners, and only `workflow_dispatch` — same policy as the GPU ECT subset.
+Bit-for-bit (BFB) workflows compare history output in single precision for CPU runs (240km case; see the BFB section in [`.github/ci-config.env`](.github/ci-config.env)). They run on **`workflow_dispatch`**, and CPU BFB callers also run on push to **`hackathon-*`**, **`hackathon`**, **`hackathon/**`**, or legacy **`feature-ci-bfb`**. **GPU BFB** workflows (`bfb-io-gpu`, `bfb-decomp-gpu`) use NVHPC + CUDA + OpenACC, double precision, CIRRUS runners, and only `workflow_dispatch` — same policy as the GPU ECT subset.
 
 | Test | Status |
 |------|--------|
@@ -53,7 +53,7 @@ Image tags, compiler mappings, and MPI flags are configured in [`.github/ci-conf
 - Use **`master`** as the base branch. Maintainer reference: [`.github/AGENT_GUIDE.md`](.github/AGENT_GUIDE.md).
 - **Fork → branch → PR** into [`NCAR/MPAS-Model-CI`](https://github.com/NCAR/MPAS-Model-CI) with base **`master`** (not the upstream `MPAS-Dev/MPAS-Model` fork unless that is intentional).
 - **Test another MPAS fork or commit:** Actions → **Cross-Repo Test** or use **`workflow_dispatch`** on **Ensemble Consistency Test (ECT)**, **coverage**, or **ect-ensemble-gen** with `mpas-repository` / `mpas-ref`. Details: [`.github/docs/testing-upstream-commits.md`](.github/docs/testing-upstream-commits.md).
-- **GPU ECT** (`test-gpu-mpich` / `test-gpu-openmpi`) runs on **push** and **in-repo PRs** targeting **`hackathon-*`** (fork PRs skip GPU until a maintainer merges — merge **push** then runs GPU). **GPU BFB** and **Nsight profiling** stay **manual dispatch**; coordinate with maintainers as needed.
+- **GPU ECT** (`test-gpu-mpich` / `test-gpu-openmpi`) is **`workflow_dispatch` only** (CIRRUS self-hosted — not tied to `hackathon-*` pushes). **GPU BFB** and **Nsight profiling** are also **manual dispatch**; coordinate with maintainers as needed.
 
 The Model for Prediction Across Scales (MPAS) is a collaborative project for
 developing atmosphere, ocean, and other earth-system simulation components for

--- a/README.md
+++ b/README.md
@@ -14,14 +14,12 @@ Thanks to Teo Price-Broncucia and Allison Baker for their help on ensemble consi
 |----------|-----|--------|--------|-----------|
 | GNU | MPICH | CPU | [![GNU+MPICH (CPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gcc-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gcc-mpich.yml) | `hpcdev:almalinux9-gcc14-mpich-26.02` |
 | GNU | OpenMPI | CPU | [![GNU+OpenMPI (CPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gcc-openmpi.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gcc-openmpi.yml) | `hpcdev:almalinux9-gcc14-openmpi-26.02` |
-| Intel | MPICH | CPU | [![Intel+MPICH (CPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-intel-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-intel-mpich.yml) | `hpcdev:leap-oneapi-mpich-25.09`\* |
-| Intel | OpenMPI | CPU | [![Intel+OpenMPI (CPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-intel-openmpi.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-intel-openmpi.yml) | `hpcdev:leap-oneapi-openmpi-25.09`\* |
+| Intel | MPICH | CPU | [![Intel+MPICH (CPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-intel-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-intel-mpich.yml) | `hpcdev:almalinux9-oneapi-mpich-26.02` |
+| Intel | OpenMPI | CPU | [![Intel+OpenMPI (CPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-intel-openmpi.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-intel-openmpi.yml) | `hpcdev:almalinux9-oneapi-openmpi-26.02` |
 | NVHPC | MPICH | CPU | [![NVHPC+MPICH (CPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-nvhpc-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-nvhpc-mpich.yml) | `hpcdev:almalinux9-nvhpc-mpich-26.02` |
 | NVHPC | OpenMPI | CPU | [![NVHPC+OpenMPI (CPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-nvhpc-openmpi.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-nvhpc-openmpi.yml) | `hpcdev:almalinux9-nvhpc-openmpi-26.02` |
 | NVHPC | MPICH | GPU | [![NVHPC+MPICH (GPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-mpich.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-mpich.yml) | `hpcdev:almalinux9-nvhpc-mpich-cuda-26.02` |
 | NVHPC | OpenMPI | GPU | [![NVHPC+OpenMPI (GPU)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-openmpi.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/test-gpu-openmpi.yml) | `hpcdev:almalinux9-nvhpc-openmpi-cuda-26.02` |
-
-\* Intel pinned to `hpcdev 25.09` (IFX 2025.2) to avoid an IFX 2025.3 preprocessor regression. This issue has been addressed by [MPAS-Dev:develop #1392](https://github.com/MPAS-Dev/MPAS-Model/pull/1392)
 
 **Compile-only** workflows verify the NVHPC + OpenACC + CUDA toolchain by building on a Github Action runner without a GPU
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Image tags, compiler mappings, and MPI flags are configured in [`.github/ci-conf
 
 ### Hackathon quick start
 
-- Use **`master`** as the base branch. Maintainer reference: [`.github/AGENT_GUIDE.md`](.github/AGENT_GUIDE.md).
+- Use **`master`** as the base branch. Shared CI settings and container tags are in [`.github/ci-config.env`](.github/ci-config.env); reusable workflows live under [`.github/workflows/`](.github/workflows/).
 - **Fork → branch → PR** into [`NCAR/MPAS-Model-CI`](https://github.com/NCAR/MPAS-Model-CI) with base **`master`** (not the upstream `MPAS-Dev/MPAS-Model` fork unless that is intentional).
 - **Test another MPAS fork or commit:** Actions → **Cross-Repo Test** or use **`workflow_dispatch`** on **Ensemble Consistency Test (ECT)**, **coverage**, or **ect-ensemble-gen** with `mpas-repository` / `mpas-ref`. Details: [`.github/docs/testing-upstream-commits.md`](.github/docs/testing-upstream-commits.md).
 - **GPU ECT** (`test-gpu-mpich` / `test-gpu-openmpi`) is **`workflow_dispatch` only** (CIRRUS self-hosted — not tied to `hackathon-*` pushes). **GPU BFB** and **Nsight profiling** are also **manual dispatch**; coordinate with maintainers as needed.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ Thanks to Teo Price-Broncucia and Allison Baker for their help on ensemble consi
 
 \* Intel pinned to `hpcdev 25.09` (IFX 2025.2) to avoid an IFX 2025.3 preprocessor regression. This issue has been addressed by [MPAS-Dev:develop #1392](https://github.com/MPAS-Dev/MPAS-Model/pull/1392)
 
-† **NVHPC+OpenMPI** ECT is fragile (suspected OpenMPI runtime issues: CPU job may exit 134 on GA runners; GPU path is **`workflow_dispatch` only** on CIRRUS). Badges reflect the latest workflow run — use **MPICH** subsets for routine green CI.
-
 **Compile-only** workflows verify the NVHPC + OpenACC + CUDA toolchain by building on a Github Action runner without a GPU
 
 


### PR DESCRIPTION
## Summary

This branch bundles several CI and documentation updates.

### Security
- **GPU ECT** workflow_dispatch only

### Intel / OneAPI
- Remove \CONTAINER_IMAGE_oneapi\ override so OneAPI uses the default **\lmalinux9-oneapi-{mpi}-26.02\** template (upstream IFX/fpp workaround is expected on \master\).
- README Intel container strings updated; Intel pin footnote removed.

### README
- Remove the NVHPC+OpenMPI fragility footnote.
- Hackathon / CI pointers use \ci-config.env\ and \.github/workflows/\ instead of \AGENT_GUIDE.md\.

### Docs and comments
- Drop public references to \AGENT_GUIDE.md\ (README, \ci-config.env\ KNOWN ISSUES, BFB caller headers, ISS talk outline). KNOWN ISSUES in \ci-config.env\ now has brief inline notes.
- Minor: remove the extra Intel comment under per-compiler overrides in \ci-config.env\.

## Verification
- After merge, confirm **Intel+MPICH** / **Intel+OpenMPI** ECT workflows succeed on current \master\ sources.
- GPU ECT remains manual-only; hackathon CPU \hackathon-*\ triggers are unchanged.

Made with [Cursor](https://cursor.com)