### PR TITLE
BFB NVHPC CPU vs GPU

### DIFF
--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -137,15 +137,16 @@ The reusable workflow `_test-bfb.yml` takes a **`variants`** input: a JSON **arr
 | `id` | yes | Unique slug (letters, digits, `.`, `_`, `-`); used for artifacts and working directories |
 | `ranks` | yes | MPI process count for that run |
 | `use_pio` | no | If true, build/link PIO for that variant’s build profile (default false = SMIOL) |
+| `openacc` | no | Per-variant OpenACC + CUDA/CIRRUS vs CPU/GitHub-hosted; omitted variants use workflow **`gpu`** input (`true` = all GPU, `false` = all CPU). Set **`gpu: 'false'`** and explicit **`openacc`** on each variant to mix NVHPC CPU and GPU (**`bfb-nvhpc-cpu-vs-gpu.yml`**) |
 | `label` | no | Short description for logs and the compare summary (defaults to `id`) |
 | `resolution` | no | Test case resolution for that run only (defaults to workflow `resolution` / `BFB_RESOLUTION`) |
 | `run_duration` | no | `config_run_duration` for that run only (defaults to workflow `run-duration` / `BFB_RUN_DURATION`) |
 
-Variants that share the same `use_pio` value reuse one compiled executable. The variant at **`reference_index`** (default **0**) is the reference; every other variant’s history file is compared to it (variable data, not raw file bytes — see `.github/scripts/compare-bfb-nc.py`).
+Variants that share the same **`use_pio`** and **`openacc`** mode reuse one compiled executable (when both CPU and OpenACC builds exist in one workflow, artifact names gain `-cpu` / `-openacc` suffixes). The variant at **`reference_index`** (default **0**) is the reference; every other variant’s history file is compared to it (variable data, not raw file bytes — see `.github/scripts/compare-bfb-nc.py`).
 
-**GPU BFB:** set workflow input **`gpu: 'true'`** (string). `_test-bfb.yml` then resolves **`CONTAINER_IMAGE_GPU`**, builds with **`openacc: true`**, and runs build/run jobs on **`CIRRUS-4x8-gpu`**. **`compiler` must be `nvhpc`**. Precision is typically **`double`** to match `_test-gpu.yml`. Example callers: **`bfb-decomp-gpu.yml`** (1 vs 4 ranks), **`bfb-io-gpu.yml`** (SMIOL vs PIO, 4 ranks). Do **not** add `pull_request` triggers for GPU BFB — same policy as `_test-gpu.yml`.
+**GPU BFB (uniform OpenACC):** set workflow input **`gpu: 'true'`** (string). `_test-bfb.yml` uses the CUDA image, **`openacc: true`** for every variant, and **`CIRRUS-4x8-gpu`** for build/run. **`compiler` must be `nvhpc`**. Precision is typically **`double`**. Example callers: **`bfb-decomp-gpu.yml`**, **`bfb-io-gpu.yml`**. Do **not** add `pull_request` triggers for GPU BFB — same policy as `_test-gpu.yml`.
 
-**Adding a new BFB test:** copy `bfb-io.yml`, `bfb-decomp.yml`, `bfb-io-gpu.yml`, or `bfb-decomp-gpu.yml`, set `name` and `on`, and edit **`variants`** (and `gpu` / `precision` when applicable). MPI rank count and PIO vs SMIOL are common examples only; any future per-run knob exposed on `variants` and implemented in `_test-bfb.yml` / composite actions can be combined the same way.
+**Adding a new BFB test:** copy `bfb-io.yml`, `bfb-decomp.yml`, `bfb-io-gpu.yml`, `bfb-decomp-gpu.yml`, or **`bfb-nvhpc-cpu-vs-gpu.yml`**, set `name` and `on`, and edit **`variants`** (and `gpu` / `precision` / per-variant **`openacc`** when applicable). MPI rank count and PIO vs SMIOL are common examples only; any future per-run knob exposed on `variants` and implemented in `_test-bfb.yml` / composite actions can be combined the same way.
 
 ## Container Environment
 

--- a/.github/workflows/_test-bfb.yml
+++ b/.github/workflows/_test-bfb.yml
@@ -363,8 +363,12 @@ jobs:
               return
             fi
 
+            # compare-bfb-nc.py exits 1 on mismatch; with `set -e`, command substitution
+            # would abort before STATUS/DETAIL are handled — temporarily disable -e.
+            set +e
             RESULT=$(python3 "${GITHUB_WORKSPACE}/.github/scripts/compare-bfb-nc.py" "${ref_file}" "${test_file}")
             STATUS=$?
+            set -e
             IFS=$'\t' read -r CODE DETAIL <<< "${RESULT}"
 
             if [ "${STATUS}" -eq 0 ] && [ "${CODE}" = "OK" ]; then

--- a/.github/workflows/_test-bfb.yml
+++ b/.github/workflows/_test-bfb.yml
@@ -4,7 +4,9 @@
 # produce bitwise-identical history variable data. The first variant (or
 # reference_index) is the reference; every other variant is compared against it.
 #
-# Optional input `gpu: 'true'`: CUDA container, OpenACC build, CIRRUS runners (nvhpc only).
+# Optional input `gpu: 'true'`: all variants use CUDA image + OpenACC + CIRRUS (nvhpc only).
+# Alternatively set `gpu: 'false'` and add per-variant `"openacc": true|false` to mix
+# CPU (GitHub-hosted) and GPU (CIRRUS) NVHPC builds in one comparison.
 #
 # MPI rank count and PIO vs SMIOL are common dimensions but not special — add any
 # new scenario by appending another variant object (and a small caller workflow).
@@ -29,8 +31,8 @@ on:
       variants:
         description: >
           JSON array of at least two variant objects. Required per variant: id (unique slug),
-          ranks (MPI processes). Optional: use_pio (default false), label (summary text),
-          resolution, run_duration (override workflow defaults for that variant only).
+          ranks (MPI processes). Optional: use_pio (default false), openacc (default follows gpu input),
+          label (summary text), resolution, run_duration (override workflow defaults for that variant only).
         required: true
         type: string
       resolution:
@@ -69,9 +71,8 @@ jobs:
     name: Resolve Config
     runs-on: ubuntu-latest
     outputs:
-      image: ${{ steps.container.outputs.image }}
-      build_tags: ${{ steps.variants.outputs.build_tags }}
-      run_variants: ${{ steps.variants.outputs.run_variants }}
+      build_matrix: ${{ steps.matrices.outputs.build_matrix }}
+      run_variants: ${{ steps.matrices.outputs.run_variants }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -87,20 +88,11 @@ jobs:
             exit 1
           fi
 
-      - uses: ./.github/actions/resolve-container
-        id: container
-        with:
-          compiler: ${{ inputs.compiler }}
-          mpi: ${{ inputs.mpi }}
-          gpu: ${{ inputs.gpu == 'true' && 'cuda' || '' }}
-
       - name: Parse variants
-        id: variants
+        id: parse
         shell: bash
         env:
           VARIANTS_JSON: ${{ inputs.variants }}
-          DEF_RES: ${{ inputs.resolution }}
-          DEF_DUR: ${{ inputs.run-duration }}
           REF_IDX: ${{ inputs.reference_index }}
         run: |
           set -euo pipefail
@@ -117,23 +109,106 @@ jobs:
             exit 1
           fi
 
-          BUILD_TAGS=$(echo "${VARIANTS_JSON}" | jq -c \
-            '[.[] | (if (.use_pio // false) then "pio" else "smiol" end)] | unique')
-          RUN_VARIANTS=$(echo "${VARIANTS_JSON}" | jq -c \
-            --arg defres "${DEF_RES}" \
-            --arg defdur "${DEF_DUR}" \
-            '[.[] | {
-              id,
-              build_tag: (if (.use_pio // false) then "pio" else "smiol" end),
-              ranks: (.ranks | tonumber),
-              resolution: (.resolution // $defres),
-              run_duration: (.run_duration // $defdur),
-              label: (.label // .id)
-            }]')
+          GDEF_JSON='false'
+          [ "${{ inputs.gpu }}" = "true" ] && GDEF_JSON='true'
+          NEED_CUDA=$(echo "${VARIANTS_JSON}" | jq -r --argjson gdef "${GDEF_JSON}" 'any(.[]; (.openacc // $gdef))')
+          echo "need_cuda=${NEED_CUDA}" >> "$GITHUB_OUTPUT"
 
-          echo "build_tags=${BUILD_TAGS}" >> "$GITHUB_OUTPUT"
+      - name: Require nvhpc for OpenACC variants
+        if: ${{ steps.parse.outputs.need_cuda == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.compiler }}" != "nvhpc" ]; then
+            echo "::error::OpenACC variants require compiler=nvhpc (got ${{ inputs.compiler }})"
+            exit 1
+          fi
+
+      - uses: ./.github/actions/resolve-container
+        id: container_cpu
+        with:
+          compiler: ${{ inputs.compiler }}
+          mpi: ${{ inputs.mpi }}
+          gpu: ''
+
+      - uses: ./.github/actions/resolve-container
+        id: container_cuda
+        if: ${{ steps.parse.outputs.need_cuda == 'true' }}
+        with:
+          compiler: ${{ inputs.compiler }}
+          mpi: ${{ inputs.mpi }}
+          gpu: cuda
+
+      - name: Compute build and run matrices
+        id: matrices
+        shell: bash
+        env:
+          VARIANTS_JSON: ${{ inputs.variants }}
+          DEF_RES: ${{ inputs.resolution }}
+          DEF_DUR: ${{ inputs.run-duration }}
+          CPU_IMG: ${{ steps.container_cpu.outputs.image }}
+          CUDA_IMG: ${{ steps.container_cuda.outputs.image }}
+        run: |
+          set -euo pipefail
+          GDEF_JSON='false'
+          [ "${{ inputs.gpu }}" = "true" ] && GDEF_JSON='true'
+
+          if [ "${{ steps.parse.outputs.need_cuda }}" = "true" ] && [ -z "${CUDA_IMG}" ]; then
+            echo "::error::CUDA container image missing but OpenACC variants are present"
+            exit 1
+          fi
+
+          MIXED=$(echo "${VARIANTS_JSON}" | jq -c --argjson gdef "${GDEF_JSON}" \
+            '([.[] | (.openacc // $gdef)] | unique | length) > 1')
+
+          BUILD_MATRIX=$(echo "${VARIANTS_JSON}" | jq -c --argjson gdef "${GDEF_JSON}" \
+            --argjson mixed "${MIXED}" --arg cpuimg "${CPU_IMG}" --arg cudaimg "${CUDA_IMG}" '
+            [.[] | {
+              build_tag: (if (.use_pio // false) then "pio" else "smiol" end),
+              openacc: (.openacc // $gdef)
+            }]
+            | unique_by("\(.build_tag)-\(.openacc)")
+            | map(. + {
+                image: (if .openacc then $cudaimg else $cpuimg end),
+                artifact_name: (
+                  if $mixed then
+                    ("exe-bfb-" + .build_tag + "-" + (if .openacc then "openacc" else "cpu" end))
+                  else
+                    ("exe-bfb-" + .build_tag)
+                  end
+                )
+              })
+          ')
+
+          RUN_VARIANTS=$(echo "${VARIANTS_JSON}" | jq -c --argjson gdef "${GDEF_JSON}" \
+            --argjson mixed "${MIXED}" --arg cpuimg "${CPU_IMG}" --arg cudaimg "${CUDA_IMG}" \
+            --arg defres "${DEF_RES}" --arg defdur "${DEF_DUR}" \
+            '[.[] |
+              (if (.use_pio // false) then "pio" else "smiol" end) as $bt |
+              (.openacc // $gdef) as $oa |
+              {
+                id,
+                build_tag: $bt,
+                openacc: $oa,
+                ranks: (.ranks | tonumber),
+                resolution: (.resolution // $defres),
+                run_duration: (.run_duration // $defdur),
+                label: (.label // .id),
+                image: (if $oa then $cudaimg else $cpuimg end),
+                artifact_name: (
+                  if $mixed then
+                    ("exe-bfb-" + $bt + "-" + (if $oa then "openacc" else "cpu" end))
+                  else
+                    ("exe-bfb-" + $bt)
+                  end
+                )
+              }
+            ]')
+
+          echo "build_matrix=${BUILD_MATRIX}" >> "$GITHUB_OUTPUT"
           echo "run_variants=${RUN_VARIANTS}" >> "$GITHUB_OUTPUT"
-          echo "Build matrix (unique I/O builds): ${BUILD_TAGS}"
+          echo "mixed_openacc_modes=${MIXED}" >> "$GITHUB_OUTPUT"
+          echo "Build matrix: ${BUILD_MATRIX}"
           echo "Run matrix: ${RUN_VARIANTS}"
 
   build:
@@ -141,11 +216,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        build_tag: ${{ fromJSON(needs.config.outputs.build_tags) }}
-    name: Build (${{ matrix.build_tag }})
-    runs-on: ${{ inputs.gpu == 'true' && fromJSON('{"group":"CIRRUS-4x8-gpu"}') || 'ubuntu-latest' }}
+        include: ${{ fromJSON(needs.config.outputs.build_matrix) }}
+    name: Build (${{ matrix.build_tag }}, ${{ matrix.openacc && 'openacc' || 'cpu' }})
+    runs-on: ${{ matrix.openacc && fromJSON('{"group":"CIRRUS-4x8-gpu"}') || 'ubuntu-latest' }}
     container:
-      image: ${{ needs.config.outputs.image }}
+      image: ${{ matrix.image }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -156,13 +231,13 @@ jobs:
         with:
           compiler: ${{ inputs.compiler }}
           use-pio: ${{ matrix.build_tag == 'pio' && 'true' || 'false' }}
-          openacc: ${{ inputs.gpu == 'true' && 'true' || 'false' }}
+          openacc: ${{ matrix.openacc && 'true' || 'false' }}
           precision: ${{ inputs.precision }}
 
       - name: Upload executable
         uses: actions/upload-artifact@v6
         with:
-          name: exe-bfb-${{ matrix.build_tag }}
+          name: ${{ matrix.artifact_name }}
           path: atmosphere_model
           retention-days: 1
 
@@ -173,19 +248,19 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.config.outputs.run_variants) }}
     name: Run (${{ matrix.id }})
-    runs-on: ${{ inputs.gpu == 'true' && fromJSON('{"group":"CIRRUS-4x8-gpu"}') || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.openacc && fromJSON('{"group":"CIRRUS-4x8-gpu"}') || 'ubuntu-latest' }}
     container:
-      image: ${{ needs.config.outputs.image }}
+      image: ${{ matrix.image }}
     steps:
       - uses: actions/checkout@v5
 
       - name: Download executable
         uses: actions/download-artifact@v7
         with:
-          name: exe-bfb-${{ matrix.build_tag }}
+          name: ${{ matrix.artifact_name }}
 
       - name: Check GPU availability
-        if: ${{ inputs.gpu == 'true' }}
+        if: ${{ matrix.openacc }}
         run: |
           echo "=== GPU Information ==="
           nvidia-smi || echo "WARNING: nvidia-smi failed"

--- a/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
+++ b/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
@@ -2,12 +2,19 @@
 # Same MPI, rank count, resolution, and double precision — compares history variable
 # data bitwise. CPU vs GPU OpenACC often differs; this workflow makes that visible.
 #
-# workflow_dispatch only (CIRRUS + mixed runners).
+# workflow_dispatch for routine use. pull_request (path-filtered) runs the same
+# workflow from the PR head so you can test before merging to master; GitHub does
+# not allow workflow_dispatch on a YAML file that only exists on a feature branch.
 
 name: "BFB: NVHPC CPU vs GPU (OpenACC)"
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [master]
+    paths:
+      - '.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml'
+      - '.github/workflows/_test-bfb.yml'
 
 jobs:
   test:

--- a/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
+++ b/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
@@ -1,0 +1,23 @@
+# BFB: NVHPC without OpenACC (GitHub-hosted) vs NVHPC + OpenACC (CIRRUS GPU).
+# Same MPI, rank count, resolution, and double precision — compares history variable
+# data bitwise. CPU vs GPU OpenACC often differs; this workflow makes that visible.
+#
+# workflow_dispatch only (CIRRUS + mixed runners).
+
+name: "BFB: NVHPC CPU vs GPU (OpenACC)"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: ./.github/workflows/_test-bfb.yml
+    with:
+      compiler: nvhpc
+      mpi: mpich
+      gpu: 'false'
+      precision: double
+      run-timeout: '20'
+      variants: >-
+        [{"id":"cpu","ranks":4,"openacc":false,"label":"NVHPC CPU (no OpenACC)"},
+         {"id":"gpu","ranks":4,"openacc":true,"label":"NVHPC GPU (OpenACC)"}]

--- a/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
+++ b/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
@@ -2,9 +2,9 @@
 # Same MPI, rank count, resolution, and double precision — compares history variable
 # data bitwise. CPU vs GPU OpenACC often differs; this workflow makes that visible.
 #
-# workflow_dispatch for routine use. pull_request (path-filtered) runs the same
-# workflow from the PR head so you can test before merging to master; GitHub does
-# not allow workflow_dispatch on a YAML file that only exists on a feature branch.
+# workflow_dispatch for routine use (after this file is on the default branch).
+# pull_request runs when this caller file changes on a PR to master so you can
+# exercise the reusable _test-bfb.yml from the PR head before merge.
 
 name: "BFB: NVHPC CPU vs GPU (OpenACC)"
 

--- a/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
+++ b/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
@@ -14,7 +14,6 @@ on:
     branches: [master]
     paths:
       - '.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml'
-      - '.github/workflows/_test-bfb.yml'
 
 jobs:
   test:

--- a/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
+++ b/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
@@ -3,17 +3,12 @@
 # data bitwise. CPU vs GPU OpenACC often differs; this workflow makes that visible.
 #
 # workflow_dispatch for routine use (after this file is on the default branch).
-# pull_request runs when this caller file changes on a PR to master so you can
-# exercise the reusable _test-bfb.yml from the PR head before merge.
+# GPU/OpenACC comparisons remain dispatch-only so PR code cannot run on CIRRUS.
 
 name: "BFB: NVHPC CPU vs GPU (OpenACC)"
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [master]
-    paths:
-      - '.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml'
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Thanks to Teo Price-Broncucia and Allison Baker for their help on ensemble consi
 
 ### Additional testing 
 
-Bit-for-bit (BFB) workflows compare history output in single precision for CPU runs (240km case; see the BFB section in [`.github/ci-config.env`](.github/ci-config.env)). They run on **`workflow_dispatch`**, and CPU BFB callers also run on push to **`hackathon-*`**, **`hackathon`**, **`hackathon/**`**, or legacy **`feature-ci-bfb`**. **GPU BFB** workflows (`bfb-io-gpu`, `bfb-decomp-gpu`, `bfb-nvhpc-cpu-vs-gpu`) use NVHPC + CUDA + OpenACC where applicable, double precision for GPU-side callers, CIRRUS for OpenACC build/run, and only `workflow_dispatch` — same policy as the GPU ECT subset.
+Bit-for-bit (BFB) workflows compare history output in single precision for CPU runs (240km case; see the BFB section in [`.github/ci-config.env`](.github/ci-config.env)). They run on **`workflow_dispatch`**, and CPU BFB callers also run on push to **`hackathon-*`**, **`hackathon`**, **`hackathon/**`**, or legacy **`feature-ci-bfb`**. **GPU BFB** workflows use NVHPC + CUDA + OpenACC where applicable, double precision for GPU-side callers, and CIRRUS for OpenACC build/run. The `bfb-io-gpu` and `bfb-decomp-gpu` workflows are `workflow_dispatch` only, while `bfb-nvhpc-cpu-vs-gpu` currently also includes a `pull_request` trigger.
 
 | Test | Status |
 |------|--------|

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Thanks to Teo Price-Broncucia and Allison Baker for their help on ensemble consi
 
 ### Additional testing 
 
-Bit-for-bit (BFB) workflows compare history output in single precision for CPU runs (240km case; see the BFB section in [`.github/ci-config.env`](.github/ci-config.env)). They run on **`workflow_dispatch`**, and CPU BFB callers also run on push to **`hackathon-*`**, **`hackathon`**, **`hackathon/**`**, or legacy **`feature-ci-bfb`**. **GPU BFB** workflows (`bfb-io-gpu`, `bfb-decomp-gpu`) use NVHPC + CUDA + OpenACC, double precision, CIRRUS runners, and only `workflow_dispatch` — same policy as the GPU ECT subset.
+Bit-for-bit (BFB) workflows compare history output in single precision for CPU runs (240km case; see the BFB section in [`.github/ci-config.env`](.github/ci-config.env)). They run on **`workflow_dispatch`**, and CPU BFB callers also run on push to **`hackathon-*`**, **`hackathon`**, **`hackathon/**`**, or legacy **`feature-ci-bfb`**. **GPU BFB** workflows (`bfb-io-gpu`, `bfb-decomp-gpu`, `bfb-nvhpc-cpu-vs-gpu`) use NVHPC + CUDA + OpenACC where applicable, double precision for GPU-side callers, CIRRUS for OpenACC build/run, and only `workflow_dispatch` — same policy as the GPU ECT subset.
 
 | Test | Status |
 |------|--------|
@@ -39,6 +39,7 @@ Bit-for-bit (BFB) workflows compare history output in single precision for CPU r
 | BFB: Decomposition (1 vs 4 ranks) | [![BFB: Decomposition (1 vs 4 ranks)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp.yml) |
 | BFB: I/O GPU (SMIOL vs PIO) | [![BFB: I/O GPU (SMIOL vs PIO)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-io-gpu.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-io-gpu.yml) |
 | BFB: Decomposition GPU (1 vs 4 ranks) | [![BFB: Decomposition GPU (1 vs 4 ranks)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp-gpu.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-decomp-gpu.yml) |
+| BFB: NVHPC CPU vs GPU | [![BFB: NVHPC CPU vs GPU](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-nvhpc-cpu-vs-gpu.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/bfb-nvhpc-cpu-vs-gpu.yml) |
 | Code coverage | [![Code Coverage](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/coverage.yml/badge.svg)](https://github.com/NCAR/MPAS-Model-CI/actions/workflows/coverage.yml) [![codecov](https://codecov.io/gh/NCAR/MPAS-Model-CI/graph/badge.svg)](https://codecov.io/gh/NCAR/MPAS-Model-CI) |
 
 Container images are from [ncarcisl/hpcdev](https://hub.docker.com/r/ncarcisl/hpcdev-x86_64).


### PR DESCRIPTION
 Adds a new bit-for-bit workflow that compares NVHPC CPU (no OpenACC, GitHub-hosted)  
   and NVHPC + OpenACC (CUDA image, CIRRUS) for the same case: MPICH, 4 ranks, double  
   precision, SMIOL, default 240km BFB settings.

  Extends _test-bfb.yml so each variant can set openacc explicitly.