### PR TITLE
CI: derive ECT release tag from Registry.xml via mpas-version composite action

### DIFF
--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -57,7 +57,7 @@ tests/                           # pFUnit test infrastructure (repo root)
 
 Test case archives, ECT ensemble summary files, and ECT spin-up restarts are stored as **GitHub release assets on this repository** (`NCAR/MPAS-Model-CI`). Each asset is versioned by its own release tag (independent of the others).
 
-Current tags: `testdata-240km-v1`, `testdata-120km-v1`, `ect-summary-v1`, `ect-restart-v1` (see `RELEASE_*` variables in `ci-config.env`).
+Current tags: `testdata-240km-v1`, `testdata-120km-v1` (see `RELEASE_TESTDATA_*` in `ci-config.env`), plus `ect-v{MPAS_VERSION}` for ECT data — its tag is derived at runtime from `src/core_atmosphere/Registry.xml` via the `mpas-version` composite action, not from `ci-config.env`.
 
 **Adding a new test case:** build the archive (`{resolution}.tar.gz`), create a release (`gh release create … --repo NCAR/MPAS-Model-CI`), attach the asset, then set `RELEASE_TESTDATA_{RES}` in `ci-config.env` (resolution uppercased with `-` → `_` in the variable name, e.g. `120KM`).
 
@@ -123,8 +123,8 @@ Key settings:
 - `NVHPC_EXTRA_MAKE_FLAGS` / `ONEAPI_EXTRA_MAKE_FLAGS` — compiler-specific build workarounds
 - `OPENMPI_RUN_FLAGS` / `MPICH_RUN_ENV_*` — MPI runtime settings
 - `RELEASE_TESTDATA_{RES}` — GitHub release tag for `{resolution}.tar.gz` test archives (`RES` uppercased, `-` → `_`)
-- `RELEASE_ECT` — release tag for ECT data (summary + restart), pinned to MPAS-Dev version
 - `ECT_*` — ECT resolution, perturbation, summary/restart filenames, excluded-vars path, etc.
+- The ECT release tag (`ect-v{MPAS_VERSION}`) is **not** stored here; it is derived at runtime from `src/core_atmosphere/Registry.xml` by the `mpas-version` composite action (see below). This guarantees the writer (`ect-ensemble-gen.yml`) and readers (`_test-compiler.yml`, `_test-gpu.yml`, `ect-test.yml`, `validate-ect`) can never drift apart.
 - `PYCECT_TAG` — PyCECT git tag for `validate-ect`
 - `BFB_*` — default resolution, duration, and run timeout for bit-for-bit workflows; per-variant overrides live in the `variants` JSON passed to `_test-bfb.yml`
 
@@ -184,7 +184,10 @@ Runs a standard MPAS-A case: uses `download-testdata`, copies the extracted tree
 Runs perturbed ensemble members for ECT. Requires explicit `run-duration` and `run-timeout` inputs. Sources `ci-config.env` for ECT settings (perturbation variable/magnitude, excluded-vars path, etc.). Activates conda, installs netCDF4/numpy, loops through members applying theta perturbation, runs the model, and trims history files. Supports restart mode.
 
 ### validate-ect
-Sources `ci-config.env` for summary filename, time slice, PyCECT tag, and `RELEASE_ECT`; downloads the summary from the matching release URL; installs deps, clones PyCECT at `PYCECT_TAG`, runs validation, writes enriched result file with dimension metadata.
+Takes a required `mpas-version` input and builds the release tag as `ect-v{mpas-version}`. Sources `ci-config.env` for summary filename, time slice, and PyCECT tag (no `RELEASE_ECT` lookup). Downloads the summary from the matching release URL, installs deps, clones PyCECT at `PYCECT_TAG`, runs validation, and writes an enriched result file with dimension metadata.
+
+### mpas-version
+Reads the MPAS version string from `src/core_atmosphere/Registry.xml` using `python3` + `xml.etree.ElementTree`. Strict — fails the workflow if the file is missing or the `<registry version="…">` attribute cannot be parsed (no silent `unknown` fallback). Single source of truth for the `ect-v{MPAS_VERSION}` release tag used by `_test-compiler.yml`, `_test-gpu.yml`, `ect-test.yml`, `ect-ensemble-gen.yml`, and `validate-ect`. Workflows that consume the version typically extract it once in their `config` job and pass it to downstream jobs as a job output.
 
 ### setup-nsight-systems
 Ensures a working `nsys` (Nsight Systems CLI) on EL-based GPU images: prefers an existing install, otherwise installs **`nsight-systems-cli`** from NVIDIA’s devtools RPM repo and caches downloaded RPMs for faster reruns (`NSYS_CLI_CACHE_VERSION` in `ci-config.env`).
@@ -198,7 +201,7 @@ Key constraints:
 - **Spin-up restart**: cold-start `init.nc` has zero hydrometeors. Ensemble generation runs 24h unperturbed first, then perturbs from the restart.
 - **PyCECT minimum members**: ensemble size must be >= number of output variables (~48). Default: 200.
 - **Time slice**: always extract last slice (`--tslice -1`) — slice 0 in cold-start mode is the unintegrated initial state.
-- ECT parameters and paths in `.github/ci-config.env` (`ECT_*`, `ECT_EXCLUDED_VARS`, `PYCECT_TAG`, release tags)
+- ECT parameters and paths in `.github/ci-config.env` (`ECT_*`, `ECT_EXCLUDED_VARS`, `PYCECT_TAG`); the ECT release tag itself is derived at runtime from `Registry.xml` via the `mpas-version` composite action.
 
 ## Shell Scripting Notes
 

--- a/.github/actions/mpas-version/action.yml
+++ b/.github/actions/mpas-version/action.yml
@@ -1,0 +1,47 @@
+name: 'Get MPAS Version'
+description: >
+  Read the MPAS version string from src/core_atmosphere/Registry.xml.
+  Strict — fails the workflow if the file is missing or the version
+  attribute cannot be parsed (no silent "unknown" fallback).
+
+inputs:
+  registry-path:
+    description: 'Path to Registry.xml relative to GITHUB_WORKSPACE'
+    required: false
+    default: 'src/core_atmosphere/Registry.xml'
+
+outputs:
+  version:
+    description: 'MPAS version string (e.g., 8.4.0)'
+    value: ${{ steps.extract.outputs.version }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: extract
+      shell: bash
+      run: |
+        python3 - "${{ inputs.registry-path }}" <<'PYEOF'
+        import os
+        import sys
+        import xml.etree.ElementTree as ET
+
+        path = sys.argv[1]
+        if not os.path.isfile(path):
+            print(f"::error::MPAS Registry not found at {path}")
+            sys.exit(1)
+        try:
+            root = ET.parse(path).getroot()
+        except ET.ParseError as e:
+            print(f"::error::Could not parse {path}: {e}")
+            sys.exit(1)
+
+        version = root.attrib.get('version')
+        if not version:
+            print(f"::error::No version attribute on <registry> in {path}")
+            sys.exit(1)
+
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write(f"version={version}\n")
+        print(f"MPAS version: {version}")
+        PYEOF

--- a/.github/actions/validate-ect/action.yml
+++ b/.github/actions/validate-ect/action.yml
@@ -12,6 +12,9 @@ inputs:
   label:
     description: 'Human-readable label for log annotations (e.g. gcc/mpich3/smiol/4proc)'
     required: true
+  mpas-version:
+    description: 'MPAS version string (used to build the ect-v{version} release tag)'
+    required: true
   dimensions:
     description: 'Multi-line key=value pairs describing this test combination (written into result file)'
     required: false
@@ -39,10 +42,12 @@ runs:
         fi
         source "${CI_CONFIG}"
 
+        # ECT release tag is derived from the MPAS version (passed in),
+        # not stored in ci-config.env. See .github/actions/mpas-version.
         echo "summary-file=${ECT_SUMMARY_FILE}" >> $GITHUB_OUTPUT
         echo "tslice=${ECT_TSLICE}" >> $GITHUB_OUTPUT
         echo "pycect-tag=${PYCECT_TAG}" >> $GITHUB_OUTPUT
-        echo "release-tag=${RELEASE_ECT}" >> $GITHUB_OUTPUT
+        echo "release-tag=ect-v${{ inputs.mpas-version }}" >> $GITHUB_OUTPUT
 
     - name: Install PyCECT dependencies
       shell: bash

--- a/.github/ci-config.env
+++ b/.github/ci-config.env
@@ -86,7 +86,15 @@ MPICH_RUN_ENV_MPIR_CVAR_ENABLE_GPU=0
 
 RELEASE_TESTDATA_240KM=testdata-240km-v1
 RELEASE_TESTDATA_120KM=testdata-120km-v1
-RELEASE_ECT=ect-v8.4.0
+
+# ── ECT release tag ──────────────────────────────
+# The ECT release tag (ect-v{MPAS_VERSION}) is derived at runtime from
+# src/core_atmosphere/Registry.xml via the .github/actions/mpas-version
+# composite action. There is no manual tag here — that ensures readers
+# (validate-ect, _test-compiler, _test-gpu, ect-test) and the writer
+# (ect-ensemble-gen) cannot drift out of sync.
+#
+# To publish ECT data for a new MPAS version, run ect-ensemble-gen.yml.
 
 
 # ── ECT configuration ────────────────────────────

--- a/.github/workflows/_test-compiler.yml
+++ b/.github/workflows/_test-compiler.yml
@@ -39,15 +39,21 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.container.outputs.image }}
+      mpas-version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v5
         with:
-          sparse-checkout: .github
+          sparse-checkout: |
+            .github
+            src/core_atmosphere/Registry.xml
+          sparse-checkout-cone-mode: false
       - uses: ./.github/actions/resolve-container
         id: container
         with:
           compiler: ${{ inputs.compiler }}
           mpi: ${{ inputs.mpi }}
+      - uses: ./.github/actions/mpas-version
+        id: version
 
   build:
     needs: config
@@ -137,6 +143,7 @@ jobs:
         run: |
           source .github/ci-config.env
           RESTART="${ECT_RESTART_FILE}"
+          RELEASE_TAG="ect-v${{ needs.config.outputs.mpas-version }}"
 
           if [ -f "spinup-restart.nc" ]; then
             echo "Using cached restart file"
@@ -146,9 +153,9 @@ jobs:
             exit 0
           fi
 
-          echo "Downloading ${RESTART}.gz from ${GITHUB_REPOSITORY} release ${RELEASE_ECT}..."
+          echo "Downloading ${RESTART}.gz from ${GITHUB_REPOSITORY} release ${RELEASE_TAG}..."
           HTTP_CODE=$(curl -sL --retry 5 --retry-delay 5 -w "%{http_code}" \
-            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_ECT}/${RESTART}.gz" \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${RESTART}.gz" \
             -o "${RESTART}.gz")
           if [ "${HTTP_CODE}" = "200" ]; then
             gunzip "${RESTART}.gz"
@@ -183,7 +190,7 @@ jobs:
           retention-days: 1
 
   ect-validate:
-    needs: ect-run
+    needs: [config, ect-run]
     if: ${{ needs.ect-run.result == 'success' }}
     name: ECT Validate (${{ inputs.compiler }}, ${{ inputs.mpi }})
     runs-on: ubuntu-latest
@@ -212,6 +219,7 @@ jobs:
         with:
           history-dir: ect-test-files
           label: ${{ inputs.compiler }}/${{ inputs.mpi }}/smiol
+          mpas-version: ${{ needs.config.outputs.mpas-version }}
           dimensions: |
             compiler=${{ inputs.compiler }}
             mpi=${{ inputs.mpi }}

--- a/.github/workflows/_test-gpu.yml
+++ b/.github/workflows/_test-gpu.yml
@@ -37,10 +37,14 @@ jobs:
     outputs:
       image: ${{ steps.container.outputs.image }}
       image-gpu: ${{ steps.gpu-container.outputs.image }}
+      mpas-version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v5
         with:
-          sparse-checkout: .github
+          sparse-checkout: |
+            .github
+            src/core_atmosphere/Registry.xml
+          sparse-checkout-cone-mode: false
       - uses: ./.github/actions/resolve-container
         id: container
         with:
@@ -52,6 +56,8 @@ jobs:
           compiler: nvhpc
           mpi: ${{ inputs.mpi }}
           gpu: cuda
+      - uses: ./.github/actions/mpas-version
+        id: version
 
   build:
     needs: config
@@ -155,6 +161,7 @@ jobs:
         run: |
           source .github/ci-config.env
           RESTART="${ECT_RESTART_FILE}"
+          RELEASE_TAG="ect-v${{ needs.config.outputs.mpas-version }}"
 
           if [ -f "spinup-restart.nc" ]; then
             echo "Using cached restart file"
@@ -164,9 +171,9 @@ jobs:
             exit 0
           fi
 
-          echo "Downloading ${RESTART}.gz from ${GITHUB_REPOSITORY} release ${RELEASE_ECT}..."
+          echo "Downloading ${RESTART}.gz from ${GITHUB_REPOSITORY} release ${RELEASE_TAG}..."
           HTTP_CODE=$(curl -sL --retry 5 --retry-delay 5 -w "%{http_code}" \
-            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_ECT}/${RESTART}.gz" \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${RESTART}.gz" \
             -o "${RESTART}.gz")
           if [ "${HTTP_CODE}" = "200" ]; then
             gunzip "${RESTART}.gz"
@@ -201,7 +208,7 @@ jobs:
           retention-days: 1
 
   ect-validate:
-    needs: ect-run
+    needs: [config, ect-run]
     if: ${{ needs.ect-run.result == 'success' }}
     name: ECT Validate (cuda, ${{ inputs.mpi }})
     runs-on: ubuntu-latest
@@ -230,6 +237,7 @@ jobs:
         with:
           history-dir: ect-test-files
           label: nvhpc/${{ inputs.mpi }}/cuda/smiol
+          mpas-version: ${{ needs.config.outputs.mpas-version }}
           dimensions: |
             compiler=nvhpc
             mpi=${{ inputs.mpi }}

--- a/.github/workflows/ect-ensemble-gen.yml
+++ b/.github/workflows/ect-ensemble-gen.yml
@@ -124,12 +124,16 @@ jobs:
         run: cp -r _ci/.github . && rm -rf _ci
 
       - name: Extract MPAS version
+        id: mpas_version
+        uses: ./.github/actions/mpas-version
+
+      - name: Resolve commit and re-export version
         id: version
+        shell: bash
         run: |
-          VERSION=$(grep -oP '<registry.*version="\K[^"]+' src/core_atmosphere/Registry.xml || echo "unknown")
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           COMMIT=$(git rev-parse --short=8 HEAD)
-          echo "mpas-version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "mpas-version=${{ steps.mpas_version.outputs.version }}" >> $GITHUB_OUTPUT
           echo "mpas-commit=${COMMIT}" >> $GITHUB_OUTPUT
 
       - name: Build MPAS-A (double precision)
@@ -460,7 +464,7 @@ jobs:
           fi
 
   #===========================================================================
-  # PUBLISH RESTART: Upload spin-up restart to RELEASE_ECT
+  # PUBLISH RESTART: Upload spin-up restart to ect-v{MPAS_VERSION}
   # Runs after spinup regardless of ensemble/summary outcome.
   # Auto-creates the release (tagged by MPAS version) if it doesn't exist.
   #===========================================================================
@@ -511,7 +515,7 @@ jobs:
           echo "  File: ${RESTART_NAME}.gz ($(du -h "${RESTART_NAME}.gz" | cut -f1))"
 
   #===========================================================================
-  # PUBLISH SUMMARY: Upload ensemble summary to RELEASE_ECT
+  # PUBLISH SUMMARY: Upload ensemble summary to ect-v{MPAS_VERSION}
   # Only runs when summary generation succeeds.
   # Auto-creates the release (tagged by MPAS version) if it doesn't exist.
   #===========================================================================
@@ -560,11 +564,6 @@ jobs:
 
           echo "=== Published summary to release ${TAG} ==="
           echo "  File: ${CURRENT_SUMMARY}"
-
-          source .github/ci-config.env
-          if [ "${RELEASE_ECT}" != "${TAG}" ]; then
-            echo "::warning::RELEASE_ECT in ci-config.env is '${RELEASE_ECT}' but this run published to '${TAG}'. Update ci-config.env to point test workflows at the new data."
-          fi
 
   #===========================================================================
   # CLEANUP

--- a/.github/workflows/ect-test.yml
+++ b/.github/workflows/ect-test.yml
@@ -33,15 +33,21 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.container.outputs.image }}
+      mpas-version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v5
         with:
-          sparse-checkout: .github
+          sparse-checkout: |
+            .github
+            src/core_atmosphere/Registry.xml
+          sparse-checkout-cone-mode: false
       - uses: ./.github/actions/resolve-container
         id: container
         with:
           compiler: gcc
           mpi: openmpi
+      - uses: ./.github/actions/mpas-version
+        id: version
 
   #===========================================================================
   # BUILD
@@ -126,8 +132,8 @@ jobs:
         run: |
           source .github/ci-config.env
           RESTART="${ECT_RESTART_FILE}"
+          RELEASE_TAG="ect-v${{ needs.config.outputs.mpas-version }}"
 
-          # Use cached file if available
           if [ -f "spinup-restart.nc" ]; then
             echo "Using cached restart file"
             mv spinup-restart.nc "${RESTART}"
@@ -136,10 +142,9 @@ jobs:
             exit 0
           fi
 
-          # Fall back to downloading from GitHub release
-          echo "Downloading ${RESTART}.gz from release ${RELEASE_ECT}..."
+          echo "Downloading ${RESTART}.gz from release ${RELEASE_TAG}..."
           HTTP_CODE=$(curl -sL --retry 3 --retry-delay 5 -w "%{http_code}" \
-            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_ECT}/${RESTART}.gz" \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${RESTART}.gz" \
             -o "${RESTART}.gz")
           if [ "${HTTP_CODE}" = "200" ]; then
             gunzip "${RESTART}.gz"
@@ -182,7 +187,7 @@ jobs:
   # VALIDATE: Run PyCECT against ensemble summary
   #===========================================================================
   validate:
-    needs: run
+    needs: [config, run]
     if: always()
     name: PyCECT Validation
     runs-on: ubuntu-latest
@@ -208,6 +213,7 @@ jobs:
         with:
           history-dir: ect-test-files
           label: gcc/openmpi/ect-standalone
+          mpas-version: ${{ needs.config.outputs.mpas-version }}
 
   #===========================================================================
   # CLEANUP


### PR DESCRIPTION
## Summary

One source of truth for the MPAS version — `src/core_atmosphere/Registry.xml` — read through a single composite action. Every workflow that builds an `ect-v{X}` release tag now derives `X` from one extraction per run, so the writer (`ect-ensemble-gen.yml`) and the readers (`_test-compiler.yml`, `_test-gpu.yml`, `ect-test.yml`, `validate-ect`) cannot drift.

### New composite action: `mpas-version`
- `.github/actions/mpas-version/action.yml` parses `Registry.xml` with `python3` + `xml.etree.ElementTree`.
- Strict — fails the run with `::error::` if the file is missing or the `<registry version="…">` attribute can't be parsed. **No silent `unknown` fallback.**

### `ci-config.env`
- Removed `RELEASE_ECT=ect-v8.4.0`. Replaced the surrounding comment with a short note that the ECT release tag is now derived at runtime.

### Workflow wiring
- `_test-compiler.yml`, `_test-gpu.yml`, `ect-test.yml`: `config` job sparse-checks out `Registry.xml`, calls the new action, exposes `mpas-version` as a job output. The restart-download step builds `ect-v${{ needs.config.outputs.mpas-version }}` directly. `ect-validate` adds `config` to `needs` and forwards the version to `validate-ect`.
- `ect-ensemble-gen.yml`: replaced the inline `grep -oP '<registry.*version="\K[^"]+' … || echo "unknown"` extractor (Perl-regex dependent; silently produced `ect-vunknown`) with the composite action. Deleted the now-obsolete `RELEASE_ECT` vs `TAG` drift warning.

### `validate-ect` action
- New required input `mpas-version`. Builds `release-tag=ect-v${{ inputs.mpas-version }}` inline; dropped the `RELEASE_ECT` lookup. Other settings (summary filename, `ECT_TSLICE`, `PYCECT_TAG`) still come from `ci-config.env`.

## Verification

End-to-end on the branch:
- [test-gcc-mpich run 24861339367](https://github.com/NCAR/MPAS-Model-CI/actions/runs/24861339367) — Resolve Config → Build → 3 × ECT member → ECT Validate → Cleanup, all green.
- [test-intel-openmpi run 24861340187](https://github.com/NCAR/MPAS-Model-CI/actions/runs/24861340187) — same, all green.

`ect-ensemble-gen.yml` will be exercised on the branch with a single-member dispatch (analysis + publish steps will fail, no new release assets uploaded).

Made with [Cursor](https://cursor.com)
