### PR TITLE
CI: surface MPAS per-rank log files in workflow logs (print-mpas-logs action)

### DIFF
--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -26,6 +26,7 @@ This is `NCAR/MPAS-Model-CI`, a fork of `MPAS-Dev/MPAS-Model`. The MPAS source c
 │   ├── run-perturb-mpas/        # Runs perturbed ensemble members for ECT
 │   │   ├── perturb_theta.py     # IC perturbation (theta field)
 │   │   └── trim_history.py      # Trims history files for artifact upload
+│   ├── print-mpas-logs/         # Dumps log.atmosphere.* into ::group:: blocks
 │   ├── validate-ect/            # PyCECT validation
 │   └── ect-summary/             # Consolidated ECT results table
 └── workflows/
@@ -188,6 +189,9 @@ Takes a required `mpas-version` input and builds the release tag as `ect-v{mpas-
 
 ### mpas-version
 Reads the MPAS version string from `src/core_atmosphere/Registry.xml` using `python3` + `xml.etree.ElementTree`. Strict — fails the workflow if the file is missing or the `<registry version="…">` attribute cannot be parsed (no silent `unknown` fallback). Single source of truth for the `ect-v{MPAS_VERSION}` release tag used by `_test-compiler.yml`, `_test-gpu.yml`, `ect-test.yml`, `ect-ensemble-gen.yml`, and `validate-ect`. Workflows that consume the version typically extract it once in their `config` job and pass it to downstream jobs as a job output.
+
+### print-mpas-logs
+Dumps MPAS per-rank log files (`log.atmosphere.<rank>.out` / `.err`) to the workflow log inside collapsible `::group::` blocks so the GitHub Actions UI gives one expandable section per file. Inputs: `log-dir` (required), `pattern` (default `log.atmosphere.*`), `max-lines` (default empty = full file; set to N to `tail -n N`). Read-only and never fails on its own — call sites should add `if: always()` so logs print on both success and failure. Already wired into `run-mpas` (reads from the run working dir) and `run-perturb-mpas` (reads from `output-dir`, where the per-member loop has copied each rank's `.out` and `.err` before tearing down the rundir).
 
 ### setup-nsight-systems
 Ensures a working `nsys` (Nsight Systems CLI) on EL-based GPU images: prefers an existing install, otherwise installs **`nsight-systems-cli`** from NVIDIA’s devtools RPM repo and caches downloaded RPMs for faster reruns (`NSYS_CLI_CACHE_VERSION` in `ci-config.env`).

--- a/.github/actions/print-mpas-logs/action.yml
+++ b/.github/actions/print-mpas-logs/action.yml
@@ -1,0 +1,60 @@
+name: 'Print MPAS Logs'
+description: >
+  Print MPAS per-rank log files (log.atmosphere.<rank>.out / .err) to the
+  workflow log inside collapsible ::group:: blocks. Read-only; never fails
+  on its own (use if: always() at the call site).
+
+inputs:
+  log-dir:
+    description: 'Directory to scan for log files'
+    required: true
+  pattern:
+    description: >
+      Glob (relative to log-dir) of files to print. Default catches both
+      .out and .err per rank.
+    required: false
+    default: 'log.atmosphere.*'
+  max-lines:
+    description: >
+      If set, print only the last N lines of each file via tail. Empty (default)
+      prints the whole file.
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Print logs
+      shell: bash
+      run: |
+        LOG_DIR="${{ inputs.log-dir }}"
+        PATTERN="${{ inputs.pattern }}"
+        MAX_LINES="${{ inputs.max-lines }}"
+
+        if [ ! -d "${LOG_DIR}" ]; then
+          echo "print-mpas-logs: directory '${LOG_DIR}' does not exist; nothing to print."
+          exit 0
+        fi
+
+        cd "${LOG_DIR}"
+        shopt -s nullglob
+
+        # Sort so .out comes before .err per rank (lexical order does this).
+        FILES=( $(ls -1 ${PATTERN} 2>/dev/null | sort) )
+
+        if [ ${#FILES[@]} -eq 0 ]; then
+          echo "print-mpas-logs: no files matching '${PATTERN}' in ${LOG_DIR}."
+          exit 0
+        fi
+
+        echo "print-mpas-logs: ${#FILES[@]} file(s) from ${LOG_DIR}"
+        for f in "${FILES[@]}"; do
+          echo "::group::${f}"
+          if [ -n "${MAX_LINES}" ]; then
+            echo "(last ${MAX_LINES} lines)"
+            tail -n "${MAX_LINES}" "${f}" || true
+          else
+            cat "${f}" || true
+          fi
+          echo "::endgroup::"
+        done

--- a/.github/actions/print-mpas-logs/action.yml
+++ b/.github/actions/print-mpas-logs/action.yml
@@ -48,6 +48,10 @@ runs:
         fi
 
         echo "print-mpas-logs: ${#FILES[@]} file(s) from ${LOG_DIR}"
+        # Close the implicit group GitHub opens for the run: script source so
+        # the per-file groups below render at the step's top level (collapsible
+        # at normal font size) instead of nested inside the script-source group.
+        echo "::endgroup::"
         for f in "${FILES[@]}"; do
           echo "::group::${f}"
           if [ -n "${MAX_LINES}" ]; then

--- a/.github/actions/run-mpas/action.yml
+++ b/.github/actions/run-mpas/action.yml
@@ -179,6 +179,12 @@ runs:
           echo "Working directory ${WORKDIR} does not exist"
         fi
 
+    - name: Print MPAS logs
+      if: always()
+      uses: ./.github/actions/print-mpas-logs
+      with:
+        log-dir: ${{ steps.config.outputs.workdir }}
+
     - name: Check run status
       shell: bash
       if: always()

--- a/.github/actions/run-perturb-mpas/action.yml
+++ b/.github/actions/run-perturb-mpas/action.yml
@@ -188,8 +188,11 @@ runs:
           set -e
           echo "[$(date +%H:%M:%S)] Model finished (exit code ${RUN_STATUS})"
 
-          for LOGFILE in log.atmosphere.*.out; do
-            [ -f "${LOGFILE}" ] && cp "${LOGFILE}" "../${OUTDIR}/${LOGFILE%.out}.member${MEMBER_ID}.out"
+          for LOGFILE in log.atmosphere.*.out log.atmosphere.*.err; do
+            [ -f "${LOGFILE}" ] || continue
+            EXT="${LOGFILE##*.}"
+            BASE="${LOGFILE%.*}"
+            cp "${LOGFILE}" "../${OUTDIR}/${BASE}.member${MEMBER_ID}.${EXT}"
           done
 
           if [ "${VERBOSE}" = "true" ]; then
@@ -273,3 +276,9 @@ runs:
           echo "::error::No ensemble members produced history files"
           exit 1
         fi
+
+    - name: Print MPAS logs
+      if: always()
+      uses: ./.github/actions/print-mpas-logs
+      with:
+        log-dir: ${{ inputs.output-dir }}


### PR DESCRIPTION
## Summary

MPAS-A writes one `log.atmosphere.<rank>.{out,err}` per MPI rank. 
Adds a small composite action `.github/actions/print-mpas-logs` that
walks a directory and dumps each matching file inside an Actions
`::group::filename` block, giving one expandable section per file in
the GitHub UI. Defaults to `log.atmosphere.*` so both `.out` and `.err`
surface

Used by 
- **`run-mpas`** — prints from the run working dir after the existing
  "List output files" step.
- **`run-perturb-mpas`** — extends the per-member cp loop to also save
  `.err` alongside `.out` (it was `.out`-only) before the rundir is
  removed, then prints from `output-dir` after the member loop completes.
