### PR TITLE
CI: align GPU BFB precision (single) + fix setup-nsight-systems YAML

### DIFF
--- a/.github/actions/setup-nsight-systems/action.yml
+++ b/.github/actions/setup-nsight-systems/action.yml
@@ -50,7 +50,7 @@ runs:
           echo "In **Settings → Actions → Caches**, search for keys starting with \`nsight-systems-cli-rpms-\`."
           echo ""
           echo "- **cache-hit** (this run): \`${{ steps.cache-nsys.outputs.cache-hit }}\`"
-      } >> "${GITHUB_STEP_SUMMARY}"
+        } >> "${GITHUB_STEP_SUMMARY}"
         if [ -d .cache/nsight-systems-rpms ]; then
           echo "- **RPM dir size:** \`$(du -sh .cache/nsight-systems-rpms 2>/dev/null || echo unknown)\`" >> "${GITHUB_STEP_SUMMARY}"
         fi

--- a/.github/workflows/bfb-decomp-gpu.yml
+++ b/.github/workflows/bfb-decomp-gpu.yml
@@ -13,7 +13,7 @@ jobs:
       compiler: nvhpc
       mpi: mpich
       gpu: 'true'
-      precision: double
+      precision: single
       run-timeout: '20'
       variants: >-
         [{"id":"r1","ranks":1,"label":"1 rank"},

--- a/.github/workflows/bfb-io-gpu.yml
+++ b/.github/workflows/bfb-io-gpu.yml
@@ -13,7 +13,7 @@ jobs:
       compiler: nvhpc
       mpi: mpich
       gpu: 'true'
-      precision: double
+      precision: single
       run-timeout: '20'
       variants: >-
         [{"id":"smiol-r4","ranks":4,"label":"SMIOL, 4 ranks"},

--- a/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
+++ b/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
@@ -1,5 +1,5 @@
 # BFB: NVHPC without OpenACC (GitHub-hosted) vs NVHPC + OpenACC (CIRRUS GPU).
-# Same MPI, rank count, resolution, and double precision — compares history variable
+# Same MPI, rank count, resolution, and single precision — compares history variable
 # data bitwise. CPU vs GPU OpenACC often differs; this workflow makes that visible.
 #
 # workflow_dispatch for routine use (after this file is on the default branch).

--- a/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
+++ b/.github/workflows/bfb-nvhpc-cpu-vs-gpu.yml
@@ -17,7 +17,7 @@ jobs:
       compiler: nvhpc
       mpi: mpich
       gpu: 'false'
-      precision: double
+      precision: single
       run-timeout: '20'
       variants: >-
         [{"id":"cpu","ranks":4,"openacc":false,"label":"NVHPC CPU (no OpenACC)"},


### PR DESCRIPTION
Two small, independent CI fixes bundled together for one merge + one
hack26 refresh.

## 1. Align GPU BFB workflows on single precision

`bfb-io.yml` and `bfb-decomp.yml` (CPU) inherit the `_test-bfb.yml`
default `precision: single`, which matches typical MPAS production
weather-forecasting builds. The three GPU BFB workflows were overriding
to `double`, creating an asymmetry that confused readers and did not
reflect any production configuration.

Drops the `precision: double` override on:
- `bfb-io-gpu`
- `bfb-decomp-gpu`
- `bfb-nvhpc-cpu-vs-gpu`

ECT correctness workflows (`_test-compiler`, `_test-gpu`, `ect-test`)
keep `precision: double` — required by ECT's perturbation magnitude.

## 2. Fix YAML indentation in setup-nsight-systems action

The closing brace of the `{ ... } >> "${GITHUB_STEP_SUMMARY}"` block
in the Nsight RPM cache step was at column 7, less than the literal
block's 8-space indent. YAML closed the scalar early and tried to
parse `} >> ...` as a new mapping key, breaking the action manifest:

```
##[error]Failed to load .github/actions/setup-nsight-systems/action.yml
```

Re-indents the closing brace to column 9. Caught by
[GPU Nsight (profile) run 24912616953](https://github.com/NCAR/MPAS-Model-CI/actions/runs/24912616953)
on `hack26_add-nvtx-markers`.

## Test plan

- BFB precision change: GPU BFB callers are dispatch-only; one-token
  change with no logical complexity, will land and be exercised
  next time someone dispatches a GPU BFB.
- Nsight YAML fix: `python3 -c "import yaml; yaml.safe_load(...)"`
  parses the manifest cleanly. The full `profile-gpu-nsight` workflow
  is dispatch-only and will be re-run by the contributor on
  `hack26_add-nvtx-markers` once this lands and `hack26` is refreshed.
