### PR TITLE
Added NVTX markers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,17 +147,17 @@ nvhpc:   # BUILDTARGET NVIDIA HPC SDK
 	"CC_SERIAL = nvc" \
 	"CXX_SERIAL = nvc++" \
 	"FFLAGS_PROMOTION = -r8" \
-	"FFLAGS_OPT = -gopt -O4 -byteswapio -Mfree" \
+	"FFLAGS_OPT = -gopt -O4 -byteswapio -Mfree -DMPAS_NVTX_RANGES" \
 	"CFLAGS_OPT = -gopt -O3" \
 	"CXXFLAGS_OPT = -gopt -O3" \
 	"LDFLAGS_OPT = -gopt -O3" \
-	"FFLAGS_DEBUG = -O0 -g -Mbounds -Mchkptr -byteswapio -Mfree -Ktrap=divz,fp,inv,ovf -traceback" \
+	"FFLAGS_DEBUG = -O0 -g -Mbounds -Mchkptr -byteswapio -Mfree -Ktrap=divz,fp,inv,ovf -traceback -DMPAS_NVTX_RANGES" \
 	"CFLAGS_DEBUG = -O0 -g -traceback" \
 	"CXXFLAGS_DEBUG = -O0 -g -traceback" \
 	"LDFLAGS_DEBUG = -O0 -g -Mbounds -Ktrap=divz,fp,inv,ovf -traceback" \
 	"FFLAGS_OMP = -mp" \
 	"CFLAGS_OMP = -mp" \
-	"FFLAGS_ACC = -Mnofma -acc -gpu=cc70,cc80 -Minfo=accel" \
+	"FFLAGS_ACC = -Mnofma -acc -gpu=cc90 -Minfo=accel" \
 	"CFLAGS_ACC =" \
 	"PICFLAG = -fpic" \
 	"BUILD_TARGET = $(@)" \
@@ -1041,6 +1041,12 @@ ifdef MPAS_EXTERNAL_CPPFLAGS
 endif
 ####################################################
 
+# NVTX Fortran wrapper must link after other libraries (Fortran runtime last from nvfortran driver).
+NVHPC_WRAP_NVTX :=
+ifeq "$(BUILD_TARGET)" "nvhpc"
+NVHPC_WRAP_NVTX := -lnvhpcwrapnvtx
+endif
+
 override CPPFLAGS += -DMPAS_BUILD_TARGET=$(BUILD_TARGET)
 
 ifeq ($(wildcard src/core_$(CORE)), ) # CHECK FOR EXISTENCE OF CORE DIRECTORY
@@ -1547,6 +1553,7 @@ mpas_main: $(MAIN_DEPS)
                  CXXFLAGS="$(CXXFLAGS)" \
                  FFLAGS="$(FFLAGS)" \
                  LDFLAGS="$(LDFLAGS)" \
+                 NVHPC_WRAP_NVTX="$(NVHPC_WRAP_NVTX)" \
                  RM="$(RM)" \
                  CPP="$(CPP)" \
                  CPPFLAGS="$(CPPFLAGS)" \

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ nvhpc:   # BUILDTARGET NVIDIA HPC SDK
 	"LDFLAGS_DEBUG = -O0 -g -Mbounds -Ktrap=divz,fp,inv,ovf -traceback" \
 	"FFLAGS_OMP = -mp" \
 	"CFLAGS_OMP = -mp" \
-	"FFLAGS_ACC = -Mnofma -acc -gpu=cc90 -Minfo=accel" \
+	"FFLAGS_ACC = -Mnofma -acc -gpu=ccnative -Minfo=accel" \
 	"CFLAGS_ACC =" \
 	"PICFLAG = -fpic" \
 	"BUILD_TARGET = $(@)" \

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ else
 all: mpas
 
 mpas: $(AUTOCLEAN_DEPS) externals frame ops dycore drver
-	$(LINKER) $(LDFLAGS) -o $(EXE_NAME) driver/*.o -L. -ldycore -lops -lframework $(LIBS) $(MPAS_ESMF_INC) $(MPAS_ESMF_LIB)
+	$(LINKER) $(LDFLAGS) -o $(EXE_NAME) driver/*.o -L. -ldycore -lops -lframework $(LIBS) $(MPAS_ESMF_INC) $(MPAS_ESMF_LIB) $(NVHPC_WRAP_NVTX)
 
 externals: $(AUTOCLEAN_DEPS)
 	( cd external; $(MAKE) FC="$(FC)" SFC="$(SFC)" CC="$(CC)" SCC="$(SCC)" FFLAGS="$(FFLAGS)" CFLAGS="$(CFLAGS)" CPP="$(CPP)" NETCDF="$(NETCDF)" CORE="$(CORE)" all )

--- a/src/framework/mpas_timer.F
+++ b/src/framework/mpas_timer.F
@@ -27,6 +27,10 @@
         use mpas_threading
         use mpas_log
 
+#ifdef MPAS_NVTX_RANGES
+        use nvtx
+#endif
+
 #ifdef MPAS_PERF_MOD_TIMERS
         use perf_mod
 #endif
@@ -109,6 +113,10 @@
           if ( present(clear_timer_in) ) then
              clear_timer = clear_timer_in
           end if
+
+#ifdef MPAS_NVTX_RANGES
+          call nvtxStartRange(trim(timer_name))
+#endif
 
 #ifdef MPAS_TAU_TIMERS
           call tau_start(trimmed_name)
@@ -254,6 +262,10 @@
 
           trimmed_name = trim(timer_name)
           nlen = len(trimmed_name)
+
+#ifdef MPAS_NVTX_RANGES
+          call nvtxEndRange()
+#endif
 
 #ifdef MPAS_TAU_TIMERS
           call tau_stop(trimmed_name)


### PR DESCRIPTION
NVTX markers are added to the code to facilitate Nsight Systems profiling. Respective flags are added to the Makefile.
The markers are added in the 'mpas_timer_start' and 'mpas_timer_stop' routines.
In addition, the compute capability flag in the Makefile is modified to 'ccnative' to generalize across the GPUs. 