### PR TITLE
CI: bump testdata to v2 (regenerated init.nc for GPU correctness)

### DIFF
--- a/.github/ci-config.env
+++ b/.github/ci-config.env
@@ -82,8 +82,8 @@ OPENMPI_RUN_FLAGS="--allow-run-as-root --oversubscribe"
 #        --repo NCAR/MPAS-Model-CI
 #   3. Add RELEASE_TESTDATA_{RESOLUTION}=testdata-{resolution}-v1 below
 
-RELEASE_TESTDATA_240KM=testdata-240km-v1
-RELEASE_TESTDATA_120KM=testdata-120km-v1
+RELEASE_TESTDATA_240KM=testdata-240km-v2
+RELEASE_TESTDATA_120KM=testdata-120km-v2
 
 # ── ECT release tag ──────────────────────────────
 # The ECT release tag (ect-v{MPAS_VERSION}) is derived at runtime from

--- a/.github/workflows/_test-compiler.yml
+++ b/.github/workflows/_test-compiler.yml
@@ -134,7 +134,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart
+          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Download spin-up restart
         if: steps.download.outcome == 'success'

--- a/.github/workflows/_test-gpu.yml
+++ b/.github/workflows/_test-gpu.yml
@@ -152,7 +152,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart
+          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Download spin-up restart
         if: steps.download.outcome == 'success'

--- a/.github/workflows/ect-ensemble-gen.yml
+++ b/.github/workflows/ect-ensemble-gen.yml
@@ -566,33 +566,25 @@ jobs:
 
   #===========================================================================
   # CLEANUP
+  # Only runs on a fully successful workflow. On any failure (batch, summary,
+  # or publish), every artifact is retained until retention-days expires so
+  # `gh run rerun --failed` can find the executable, spin-up restart, and
+  # per-batch history files it needs to recover.
   #===========================================================================
   cleanup:
     needs: [run-ensemble, generate-summary, publish-restart, publish-summary]
-    if: always()
+    if: needs.publish-summary.result == 'success'
     runs-on: ubuntu-latest
     name: Cleanup
 
     steps:
-      - name: Delete build artifacts
+      - name: Delete build and ensemble artifacts
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-            --paginate --jq '.artifacts[] | select(.name == "exe-ect-ensemble" or .name == "spinup-restart") | .id' \
-          | while read id; do
-              gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id || true
-            done || true
-
-      - name: Delete ensemble artifacts (only after successful summary)
-        if: needs.generate-summary.result == 'success'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
-            --paginate --jq '.artifacts[] | select(.name | startswith("ect-ensemble-")) | .id' \
+            --paginate --jq '.artifacts[] | select(.name == "exe-ect-ensemble" or .name == "spinup-restart" or (.name | startswith("ect-ensemble-"))) | .id' \
           | while read id; do
               gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id || true
             done || true

--- a/.github/workflows/ect-ensemble-gen.yml
+++ b/.github/workflows/ect-ensemble-gen.yml
@@ -170,7 +170,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart
+          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Download executable
         if: steps.cache.outputs.cache-hit != 'true'
@@ -212,7 +212,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart
+          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Upload restart artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ect-test.yml
+++ b/.github/workflows/ect-test.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart
+          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Download spin-up restart
         id: restart


### PR DESCRIPTION
## Summary

Bumps `RELEASE_TESTDATA_{120KM,240KM}` in `.github/ci-config.env` to v2. The MPAS GPU dev regenerated the test-case input files to fix GPU ECT failures; v2 tarballs are now published on this repo's releases.

## What's in v2

Built by overlaying only case-specific files onto the v1 tarballs. Physics tables, METIS partitions, streams definitions, and stream lists are byte-identical to v1.

**120km** ([release](https://github.com/NCAR/MPAS-Model-CI/releases/tag/testdata-120km-v2)):
- `x1.40962.init.nc` (ERA5 source, init_case=8 real-data; v1 was CFSR / init_case=7)
- `x1.40962.sfc_update.nc` (matches new start time)
- `x1.40962.static.nc` (now ships 30 GOCART aerosol levels; 53 MB → 71 MB)
- `namelist.atmosphere`: `config_start_time` 2018-04-14 → 2014-09-10
- `namelist.init_atmosphere`: provenance only (CI doesn't run init_atmosphere)

**240km** ([release](https://github.com/NCAR/MPAS-Model-CI/releases/tag/testdata-240km-v2)):
- `x1.10242.init.nc`
- `x1.10242.sfc_update.nc`
- (`namelist.atmosphere` was already 2014-09-10 in v1; no change needed)

## Workflow hardening (added this PR)

Two ECT workflow fixes uncovered while validating the v2 bump:

1. **Spin-up cache key now binds to `ci-config.env` hash.** The cache key was hardcoded `ect-spinup-restart`, so a v1 restart sat in the cache forever. After bumping testdata, the spin-up step skipped the regeneration and reused the v1 restart against v2 inputs, causing dimension-mismatch failures (`nVertLevelsP1`) downstream. Patched in `ect-ensemble-gen.yml`, `ect-test.yml`, `_test-compiler.yml`, `_test-gpu.yml`.

2. **Cleanup gated on full success.** `cleanup` ran on `if: always()` and unconditionally deleted `exe-ect-ensemble` and `spinup-restart`. When a Members batch failed and we ran `gh run rerun --failed`, the rerun's batch immediately died on "Download executable". Now `cleanup` only runs when `publish-summary` succeeded; on any failure path artifacts persist until `retention-days: 1` expires, giving 24 hours to rerun.

## Verification done

- Diffed all namelists, streams, and stream_list files between v1 tarball and dev's regenerated directory. Only the files listed above differ.
- SHA256-compared all physics tables and graph.info partition files. All identical to v1, with one exception: 240km's `graph.info.part.4` differed (METIS re-partitioning artifact on identical mesh adjacency). Kept v1's to preserve mesh-artifact stability across versions.
- Dispatched `ect-ensemble-gen` against this branch ([run 25012685608](https://github.com/NCAR/MPAS-Model-CI/actions/runs/25012685608)). Spin-up regenerated successfully against v2 inputs (~30 min real run, no cache shortcut). v2 spin-up restart was published to `ect-v8.4.0`. 18/20 Members batches succeeded; 2 batches (40-49, 50-59) died at the same step within 2 s of each other — pattern consistent with a transient runner-pool issue. A 180-member summary artifact was captured locally as a fallback.

## Required follow-up after merge

```
gh workflow run ect-ensemble-gen.yml --repo NCAR/MPAS-Model-CI --ref master
```

This will hit the spin-up cache (no 30-min spin-up rerun) and re-attempt all 200 Members batches. If any fail again, the cleanup-gate change above lets `gh run rerun --failed` recover them.

## Test plan

- [x] Read-only verification of v1-vs-v2 file deltas
- [x] Spin-up regenerates from v2 inputs end-to-end
- [x] v2 spin-up restart published to `ect-v8.4.0`
- [ ] CPU push triggers green on this PR (gcc/intel/nvhpc + MPICH/OpenMPI)
- [ ] After merge: dispatch `ect-ensemble-gen.yml` to publish 200-member v2 summary
- [ ] Dispatch `test-nvhpc-mpich (GPU)` and `ect-test.yml` to confirm GPU ECT now passes
- [ ] Cherry-pick onto hack26
