### PR TITLE
CI: bump 240km testdata to v3 (drop q2 from history streams)

### DIFF
--- a/.github/ci-config.env
+++ b/.github/ci-config.env
@@ -82,7 +82,7 @@ OPENMPI_RUN_FLAGS="--allow-run-as-root --oversubscribe"
 #        --repo NCAR/MPAS-Model-CI
 #   3. Add RELEASE_TESTDATA_{RESOLUTION}=testdata-{resolution}-v1 below
 
-RELEASE_TESTDATA_240KM=testdata-240km-v2
+RELEASE_TESTDATA_240KM=testdata-240km-v3
 RELEASE_TESTDATA_120KM=testdata-120km-v2
 
 # ── ECT release tag ──────────────────────────────


### PR DESCRIPTION
## Summary

Bumps `RELEASE_TESTDATA_240KM` from `testdata-240km-v2` to `testdata-240km-v3`. The new tarball drops `q2` from `stream_list.atmosphere.output` and `stream_list.atmosphere.diagnostics`; everything else is byte-identical to v2. `RELEASE_TESTDATA_120KM` stays on v2.

## Why

The v2 240km init.nc/sfc_update.nc puts MPAS-A into a state where the `q2` (2-m water vapor mixing ratio) diagnostic produces NaN at one or more cells in a 1-hour run with default physics. `q2` is the **only** variable that ends up NaN, and it does so in every config we tested:

| BFB workflow | Vars differing |
|---|---|
| BFB I/O (gcc, single, smiol-r4 vs pio-r4) | `q2` (NaN) |
| BFB Decomp (gcc, single, smiol-r1 vs smiol-r4) | _running on hack26 push, expected same_ |
| BFB CPU vs GPU (NVHPC, single, openacc on/off, 4r) | `q2` (NaN) plus normal CPU-vs-GPU rounding diffs (1e-5..1e-2) |

Pre-v2 BFB CPU-vs-GPU runs (double precision, v1 testdata) had no `q2` in the diff list, so this is new with the v2 240km init.

`q2` is a diagnostic only — it isn't read back into the time integration — so removing it from the history stream is a safe CI-side workaround. The underlying MPAS-A defect has been reported upstream.

## Why not bump 120km too

The 200-member ECT v8.4.0 summary that was just published references `q2` in its baseline. Bumping 120km would force another ~90-minute ECT regen for no benefit: `q2` is not NaN at 120km (ECT validation `ect-test.yml` and `test-gpu-mpich.yml` both passed cleanly with v2/120km).

## Test plan

- [x] Diff of v2 vs v3 240km tarball: only `stream_list.atmosphere.output` and `stream_list.atmosphere.diagnostics` differ; both lose exactly one line (`q2`).
- [ ] CPU push triggers green on this PR (gcc/intel/nvhpc + MPICH + smiol/pio + 1r/4r BFB pairs)
- [ ] After merge, cherry-pick onto `hack26`
