### PR TITLE
Hack26 dyntend6480 (calculating u-tend)

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6283,6 +6283,8 @@ module atm_time_integration
       real (kind=RKIND) :: theta_turb_flux, w_turb_flux, r
       real (kind=RKIND) :: scalar_weight
       real (kind=RKIND) :: inv_r_earth
+      real (kind=RKIND) :: w_below, w_above, qk
+      integer :: kp1
 
       real (kind=RKIND) :: invDt, flux, workpv
       real (kind=RKIND) :: edge_sign, pr_scale, r_dc, r_dv, u_mix_scale
@@ -6477,89 +6479,88 @@ module atm_time_integration
       ! Compute u (normal) velocity tendency for each edge (cell face)
       !
 
-      !$acc parallel default(present)
-      !$acc loop gang private(wduz, q)
-      do iEdge=edgeSolveStart,edgeSolveEnd
-
-         cell1 = cellsOnEdge(1,iEdge)
-         cell2 = cellsOnEdge(2,iEdge)
-
-         ! horizontal pressure gradient 
-
-         if(rk_step == 1) then
+!
+!     horizontal pressure gradient
+!
+      if(rk_step == 1) then
+         !$acc parallel default(present) async(1)
+         !$acc loop gang worker
+         do iEdge=edgeSolveStart,edgeSolveEnd
+            cell1 = cellsOnEdge(1,iEdge)
+            cell2 = cellsOnEdge(2,iEdge)
 !DIR$ IVDEP
             !$acc loop vector
             do k=1,nVertLevels
                tend_u_euler(k,iEdge) =  - cqu(k,iEdge)*( (pp(k,cell2)-pp(k,cell1))*invDcEdge(iEdge)/(.5*(zz(k,cell2)+zz(k,cell1))) &
                                               -0.5*zxu(k,iEdge)*(dpdz(k,cell1)+dpdz(k,cell2)) )
             end do
-
-         end if
-
-         ! vertical transport of u
-
-         wduz(1) = 0.
-
-         k = 2
-         wduz(k) =  0.5*( rw(k,cell1)+rw(k,cell2))*(fzm(k)*u(k,iEdge)+fzp(k)*u(k-1,iEdge))
-         !$acc loop vector
-         do k=3,nVertLevels-1
-            wduz(k) = flux3( u(k-2,iEdge),u(k-1,iEdge),u(k,iEdge),u(k+1,iEdge),0.5*(rw(k,cell1)+rw(k,cell2)), 1.0_RKIND )
          end do
-         k = nVertLevels
-         wduz(k) =  0.5*( rw(k,cell1)+rw(k,cell2))*(fzm(k)*u(k,iEdge)+fzp(k)*u(k-1,iEdge))
+         !$acc end parallel
+      end if
 
-         wduz(nVertLevels+1) = 0.
+!
+!     --- vertical transport + Coriolis + KE + vorticity + curvature ---
+!
+
+      !$acc parallel default(present) async(2)
+      !$acc loop gang worker
+      do iEdge=edgeSolveStart,edgeSolveEnd
+
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
 
 !DIR$ IVDEP
-         !$acc loop vector
+         !$acc loop vector private(w_below, w_above, qk, kp1)
          do k=1,nVertLevels
-            tend_u(k,iEdge) = - rdzw(k)*(wduz(k+1)-wduz(k)) !  first use of tend_u
-         end do
 
-         ! Next, nonlinear Coriolis term (q) following Ringler et al JCP 2009
+            ! --- w_below = wduz(k)
+            if (k == 1) then
+               w_below = 0.0_RKIND
+            else if (k == 2 .or. k == nVertLevels) then
+               w_below = 0.5*( rw(k,cell1)+rw(k,cell2))*(fzm(k)*u(k,iEdge)+fzp(k)*u(k-1,iEdge))
+            else
+               w_below = flux3( u(k-2,iEdge),u(k-1,iEdge),u(k,iEdge),u(k+1,iEdge), &
+                                0.5*(rw(k,cell1)+rw(k,cell2)), 1.0_RKIND )
+            end if
 
-         !$acc loop vector
-         do k=1,nVertLevels
-            q(k) = 0.0_RKIND
-         end do
+            ! --- w_above = wduz(k+1)
+            kp1 = k + 1
+            if (kp1 == nVertLevels+1) then
+               w_above = 0.0_RKIND
+            else if (kp1 == 2 .or. kp1 == nVertLevels) then
+               w_above = 0.5*( rw(kp1,cell1)+rw(kp1,cell2))*(fzm(kp1)*u(kp1,iEdge)+fzp(kp1)*u(kp1-1,iEdge))
+            else
+               w_above = flux3( u(kp1-2,iEdge),u(kp1-1,iEdge),u(kp1,iEdge),u(kp1+1,iEdge), &
+                                0.5*(rw(kp1,cell1)+rw(kp1,cell2)), 1.0_RKIND )
+            end if
 
-         !$acc loop seq
-         do j = 1,nEdgesOnEdge(iEdge)
-            eoe = edgesOnEdge(j,iEdge)
+            ! --- vertical transport of u ---
+            tend_u(k,iEdge) = -rdzw(k)*(w_above - w_below)
 
-            !$acc loop vector
-            do k=1,nVertLevels
-               workpv = 0.5 * (pv_edge(k,iEdge) + pv_edge(k,eoe))
-!  the original definition of pv_edge had a factor of 1/density.  We have removed that factor
-!  given that it was not integral to any conservation property of the system
-               q(k) = q(k) + weightsOnEdge(j,iEdge) * u(k,eoe) * workpv
-            end do
-         end do
-
-         if (perturbation_coriolis) then  !  this is correct only for constant f
+            ! --- Coriolis q accumulation ---
+            qk = 0.0_RKIND
             !$acc loop seq
             do j = 1,nEdgesOnEdge(iEdge)
                eoe = edgesOnEdge(j,iEdge)
-
-               !$acc loop vector
-               do k=1,nVertLevels
-                  reference_u = u_init(k) * cos(angleEdge(eoe)) -  v_init(k) * sin(angleEdge(eoe))
-                  q(k) = q(k) - weightsOnEdge(j,iEdge) * reference_u * fEdge(iEdge)
-!                 q(k) = q(k) - weightsOnEdge(j,iEdge) * reference_u * 0.729210E-04
-               end do
+               scalar_weight = weightsOnEdge(j,iEdge)
+               workpv = 0.5 * (pv_edge(k,iEdge) + pv_edge(k,eoe))
+               qk = qk + scalar_weight * u(k,eoe) * workpv
             end do
-         end if
 
-!DIR$ IVDEP
-         !$acc loop vector
-         do k=1,nVertLevels
+            if (perturbation_coriolis) then
+               !$acc loop seq
+               do j = 1,nEdgesOnEdge(iEdge)
+                  eoe = edgesOnEdge(j,iEdge)
+                  scalar_weight = weightsOnEdge(j,iEdge)
+                  reference_u = u_init(k) * cos(angleEdge(eoe)) -  v_init(k) * sin(angleEdge(eoe))
+                  qk = qk - scalar_weight * reference_u * fEdge(iEdge)
+               end do
+            end if
 
-            ! horizontal ke gradient and vorticity terms in the vector invariant formulation
-            ! of the horizontal momentum equation
-            tend_u(k,iEdge) = tend_u(k,iEdge) + rho_edge(k,iEdge)* (q(k) - (ke(k,cell2) - ke(k,cell1))       &
+            ! --- KE gradient + vorticity + curvature ---
+            tend_u(k,iEdge) = tend_u(k,iEdge) + rho_edge(k,iEdge)* (qk - (ke(k,cell2) - ke(k,cell1))       &
                                                                  * invDcEdge(iEdge))                            &
-                                             - u(k,iEdge)*0.5*(h_divergence(k,cell1)+h_divergence(k,cell2)) 
+                                             - u(k,iEdge)*0.5*(h_divergence(k,cell1)+h_divergence(k,cell2))
 #ifdef CURVATURE
             ! curvature terms for the sphere
             tend_u(k,iEdge) = tend_u(k,iEdge) &
@@ -6578,6 +6579,8 @@ module atm_time_integration
       !  mixing terms are integrated using forward-Euler, so this tendency is only computed in the
       !  first Runge-Kutta substep and saved for use in later RK substeps 2 and 3.
       !
+
+      !$acc wait
 
       if (rk_step == 1) then
 

--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -6478,7 +6478,7 @@ module atm_time_integration
       !
 
       !$acc parallel default(present)
-      !$acc loop gang worker private(wduz, q)
+      !$acc loop gang private(wduz, q)
       do iEdge=edgeSolveStart,edgeSolveEnd
 
          cell1 = cellsOnEdge(1,iEdge)


### PR DESCRIPTION
Initial profiling of dyntend 6480 : 

6480: compute region reached 36 times
        6480: kernel launched 36 times
            grid: [65535]  block: [32x4]
             device time(us): total=1,000,567 max=29,930 min=26,751 avg=27,793
            elapsed time(us): total=1,001,122 max=29,956 min=26,766 avg=27,808
    6480: data region reached 72 times


Current profiling, after breaking into two kernels:
 6487: compute region reached 12 times
        6487: kernel launched 12 times
            grid: [491520]  block: [32x4]
             device time(us): total=28,478 max=2,382 min=2,368 avg=2,373
            elapsed time(us): total=28,674 max=2,398 min=2,383 avg=2,389
    6487: data region reached 24 times
    6507: compute region reached 36 times
        6507: kernel launched 36 times
            grid: [491520]  block: [32x4]
             device time(us): total=495,211 max=13,826 min=13,736 avg=13,755
            elapsed time(us): total=495,811 max=13,854 min=13,752 avg=13,772
    6507: data region reached 72 times

      Replaced private wduz/q arrays with scalars (w_below, w_above, qk)
      that are computed on the fly per vector. Goal was to reduce register
      and improve GPU occupancy. 

GPU - NVHPC/MPICH ECT Results:
These runs ****PASSED**** according to our testing criterion.

PC 2: failed 1 runs  [1]
PC 7: failed 1 runs  [2]
PC 13: failed 1 runs  [1]
PC 22: failed 1 runs  [3]
PC 24: failed 1 runs  [2]

Run 1: 2 PC scores failed  [2, 13]
Run 2: 2 PC scores failed  [7, 24]
Run 3: 1 PC scores failed  [22]

Testing complete.