### PR TITLE
Update unit-tests.yml

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,6 +12,7 @@ permissions:
 
 on:
   pull_request:
+    branches: [master, develop]
     paths:
       - 'src/**'
       - 'tests/**'


### PR DESCRIPTION
The unit testing files are not included on the hack26 branch,
so the tests look like they're failing (They're not actually running).
This patch turns them off the hack26 branches, leaves them on
the master and develop branch where the files reside.

