### PR TITLE
optimizing solve_diagnostics_7276 kernel, fused two loops into one

### DIFF
--- a/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
+++ b/src/core_atmosphere/dynamics/mpas_atm_time_integration.F
@@ -7274,25 +7274,21 @@ module atm_time_integration
          ke_fact = 1.0 - .375
 
          !$acc parallel default(present)
-         !$acc loop collapse(2)
+         !$acc loop gang worker
          do iCell=cellStart,cellEnd
-            do k=1,nVertLevels
+            r = (1.0_RKIND - ke_fact) * invAreaCell(iCell)
+            !$acc loop vector
+            do k = 1,nVertLevels
                ke(k,iCell) = ke_fact * ke(k,iCell)
             end do
-         end do
-
-
-         !$acc loop gang
-         do iCell=cellStart,cellEnd
-            r = invAreaCell(iCell)
             !$acc loop seq
             do i=1,nEdgesOnCell(iCell)
                iVertex = verticesOnCell(i,iCell)
                j = kiteForCell(i,iCell)
-!DIR$ IVDEP
+         !DIR$ IVDEP
                !$acc loop vector
                do k = 1,nVertLevels
-                  ke(k,iCell) = ke(k,iCell) + (1.-ke_fact)*kiteAreasOnVertex(j,iVertex) * ke_vertex(k,iVertex) * r
+                  ke(k,iCell) = ke(k,iCell) + kiteAreasOnVertex(j,iVertex) * ke_vertex(k,iVertex) *r
                end do
             end do
          end do


### PR DESCRIPTION
fuse collapse(2) scaling loop and kite-area accumulation loop into single gang worker kernel

Initial timing:
 7276: compute region reached 37 times                                                        
          7276: kernel launched 37 times                                                       
              grid: [655362] block: [128]                                                      
               device time(us): total=208,862 max=5,649 min=5,631 avg=5,644                    
              elapsed time(us): total=209,409 max=5,664 min=5,648 avg=5,659                    
      7276: data region reached 74 times                                                       
                                          
Current timing:
     7276: compute region reached 37 times                                                    
          7276: kernel launched 37 times                                                       
              grid: [163841] block: [32x4]                                                     
               device time(us): total=91,149 max=2,468 min=2,459 avg=2,463                     
              elapsed time(us): total=91,684 max=2,484 min=2,474 avg=2,477                     
      7276: data region reached 74 times              

ECT results passed:
These runs ****PASSED**** according to our testing criterion. 
PC 9: failed 1 runs  [3]
PC 21: failed 1 runs  [2]
PC 22: failed 1 runs  [2]
PC 23: failed 1 runs  [2]
 
Run 1: 0 PC scores failed  []
Run 2: 3 PC scores failed  [21, 22, 23]
Run 3: 1 PC scores failed  [9]
 
Testing complete.
 




