### PR TITLE
ci: use DATA_REPOSITORY so forks download release data from upstream

### DIFF
--- a/.github/actions/download-testdata/action.yml
+++ b/.github/actions/download-testdata/action.yml
@@ -41,7 +41,7 @@ runs:
           exit 1
         fi
 
-        REPO="${GITHUB_REPOSITORY}"
+        REPO="${DATA_REPOSITORY:-${GITHUB_REPOSITORY}}"
         URL="https://github.com/${REPO}/releases/download/${TAG}/${ARCHIVE}"
 
         echo "release-tag=${TAG}" >> $GITHUB_OUTPUT

--- a/.github/actions/validate-ect/action.yml
+++ b/.github/actions/validate-ect/action.yml
@@ -65,7 +65,7 @@ runs:
       run: |
         SUMMARY="${{ steps.config.outputs.summary-file }}"
         TAG="${{ steps.config.outputs.release-tag }}"
-        REPO="${GITHUB_REPOSITORY}"
+        REPO="${DATA_REPOSITORY:-${GITHUB_REPOSITORY}}"
         URL="https://github.com/${REPO}/releases/download/${TAG}/${SUMMARY}"
 
         echo "Downloading ${SUMMARY} from release ${TAG}..."

--- a/.github/actions/validate-ect/action.yml
+++ b/.github/actions/validate-ect/action.yml
@@ -63,6 +63,7 @@ runs:
       id: summary
       shell: bash
       run: |
+        source .github/ci-config.env
         SUMMARY="${{ steps.config.outputs.summary-file }}"
         TAG="${{ steps.config.outputs.release-tag }}"
         REPO="${DATA_REPOSITORY:-${GITHUB_REPOSITORY}}"

--- a/.github/ci-config.env
+++ b/.github/ci-config.env
@@ -82,6 +82,10 @@ OPENMPI_RUN_FLAGS="--allow-run-as-root --oversubscribe"
 #        --repo NCAR/MPAS-Model-CI
 #   3. Add RELEASE_TESTDATA_{RESOLUTION}=testdata-{resolution}-v1 below
 
+# Repository that hosts release assets (test data, ECT summaries, restarts).
+# Forks: leave this as-is to pull data from the upstream NCAR repo.
+DATA_REPOSITORY=NCAR/MPAS-Model-CI
+
 RELEASE_TESTDATA_240KM=testdata-240km-v3
 RELEASE_TESTDATA_120KM=testdata-120km-v2
 

--- a/.github/workflows/_test-compiler.yml
+++ b/.github/workflows/_test-compiler.yml
@@ -153,9 +153,10 @@ jobs:
             exit 0
           fi
 
-          echo "Downloading ${RESTART}.gz from ${GITHUB_REPOSITORY} release ${RELEASE_TAG}..."
+          DATA_REPO="${DATA_REPOSITORY:-${GITHUB_REPOSITORY}}"
+          echo "Downloading ${RESTART}.gz from ${DATA_REPO} release ${RELEASE_TAG}..."
           HTTP_CODE=$(curl -sL --retry 5 --retry-delay 5 -w "%{http_code}" \
-            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${RESTART}.gz" \
+            "https://github.com/${DATA_REPO}/releases/download/${RELEASE_TAG}/${RESTART}.gz" \
             -o "${RESTART}.gz")
           if [ "${HTTP_CODE}" = "200" ]; then
             gunzip "${RESTART}.gz"

--- a/.github/workflows/_test-gpu.yml
+++ b/.github/workflows/_test-gpu.yml
@@ -171,9 +171,10 @@ jobs:
             exit 0
           fi
 
-          echo "Downloading ${RESTART}.gz from ${GITHUB_REPOSITORY} release ${RELEASE_TAG}..."
+          DATA_REPO="${DATA_REPOSITORY:-${GITHUB_REPOSITORY}}"
+          echo "Downloading ${RESTART}.gz from ${DATA_REPO} release ${RELEASE_TAG}..."
           HTTP_CODE=$(curl -sL --retry 5 --retry-delay 5 -w "%{http_code}" \
-            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${RESTART}.gz" \
+            "https://github.com/${DATA_REPO}/releases/download/${RELEASE_TAG}/${RESTART}.gz" \
             -o "${RESTART}.gz")
           if [ "${HTTP_CODE}" = "200" ]; then
             gunzip "${RESTART}.gz"


### PR DESCRIPTION
## Summary

- Forks of MPAS-Model-CI have no GitHub releases, so all CI test data downloads (test cases, ECT summaries, restart files) fail with 404.
- Adds `DATA_REPOSITORY=NCAR/MPAS-Model-CI` to `ci-config.env` and updates the four download locations to use it instead of `GITHUB_REPOSITORY`.
- Falls back to `GITHUB_REPOSITORY` if `DATA_REPOSITORY` is unset, so this is backward-compatible.

## Changed files

- `.github/ci-config.env` -- new `DATA_REPOSITORY` variable
- `.github/actions/download-testdata/action.yml` -- test case archive downloads
- `.github/actions/validate-ect/action.yml` -- ECT ensemble summary download
- `.github/workflows/_test-compiler.yml` -- spin-up restart download
- `.github/workflows/_test-gpu.yml` -- spin-up restart download

## Test plan

- [ ] Verify CI passes on this PR (upstream repo, `GITHUB_REPOSITORY == NCAR/MPAS-Model-CI`)
- [ ] Verify a fork can run CI without copying releases