### PR TITLE
ci: performance on cpu vs gpu

### DIFF
--- a/.github/actions/parse-mpas-timers/action.yml
+++ b/.github/actions/parse-mpas-timers/action.yml
@@ -1,0 +1,51 @@
+name: 'Parse MPAS Timers'
+description: >
+  Parse the native MPAS-A timer table (log.atmosphere.0000.out) into JSON.
+  Works on both CPU and GPU builds since the native timer framework
+  (TIMER_LIB unset -> MPAS_NATIVE_TIMERS) is on by default; no build changes
+  required.
+
+inputs:
+  log-dir:
+    description: 'Directory containing log.atmosphere.0000.out (the run working directory)'
+    required: true
+  log-file:
+    description: 'Log filename within log-dir'
+    required: false
+    default: 'log.atmosphere.0000.out'
+  output-file:
+    description: 'Path to write the parsed JSON'
+    required: true
+
+outputs:
+  json-file:
+    description: 'Path to the parsed timer JSON'
+    value: ${{ steps.parse.outputs.json-file }}
+  timer-count:
+    description: 'Number of timer rows parsed (0 if the table was not found)'
+    value: ${{ steps.parse.outputs.timer-count }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Parse timer table
+      id: parse
+      shell: bash
+      run: |
+        LOG_PATH="${{ inputs.log-dir }}/${{ inputs.log-file }}"
+        OUT="${{ inputs.output-file }}"
+
+        if [ ! -f "${LOG_PATH}" ]; then
+          echo "::error::MPAS log not found at ${LOG_PATH}"
+          exit 1
+        fi
+
+        python3 "${GITHUB_WORKSPACE}/.github/scripts/parse-mpas-timers.py" "${LOG_PATH}" "${OUT}"
+
+        COUNT=$(python3 -c "import json; print(len(json.load(open('${OUT}'))['timers']))")
+        echo "timer-count=${COUNT}" >> "$GITHUB_OUTPUT"
+        echo "json-file=${OUT}" >> "$GITHUB_OUTPUT"
+
+        if [ "${COUNT}" -eq 0 ]; then
+          echo "::warning::No timer rows parsed from ${LOG_PATH} — check that TIMER_LIB was not overridden at build time"
+        fi

--- a/.github/actions/parse-mpas-timers/action.yml
+++ b/.github/actions/parse-mpas-timers/action.yml
@@ -1,9 +1,7 @@
 name: 'Parse MPAS Timers'
 description: >
-  Parse the native MPAS-A timer table (log.atmosphere.0000.out) into JSON.
-  Works on both CPU and GPU builds since the native timer framework
-  (TIMER_LIB unset -> MPAS_NATIVE_TIMERS) is on by default; no build changes
-  required.
+  Parse the MPAS-A timer table from log.atmosphere.0000.out into JSON.
+  Works on both CPU and GPU builds
 
 inputs:
   log-dir:

--- a/.github/scripts/parse-mpas-timers.py
+++ b/.github/scripts/parse-mpas-timers.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Parse the MPAS-A native timer table out of a log.atmosphere.*.out file.
+
+MPAS-A prints a hierarchical timer table by default (TIMER_LIB unset ->
+MPAS_NATIVE_TIMERS, see src/framework/mpas_timer.F: mpas_timer_write). This
+table is emitted on every run, CPU or GPU, and includes per-routine wall-clock
+timers (e.g. atm_advance_acoustic_step, atm_compute_dyn_tend) plus, on
+OpenACC/GPU builds, additional "[ACC_data_xfer]" timers wrapping halo
+exchanges. Parsing this table gives a routine-level CPU vs GPU comparison
+with no source changes required.
+
+Row format (mpas_timer.F, mpas_timer_write):
+    write(msg,'(i2, 1x, a45, f15.5, i10, 3f15.5, 1x, f8.2, 3x, f8.2, 3x, f8.2)')
+        levels, indentation // timer_name, total_time, calls, min_time, max_time,
+        avg_time, pct_tot, pct_par, par_eff
+
+Usage:
+    parse-mpas-timers.py <log-file> <output-json>
+"""
+
+import json
+import re
+import sys
+
+# Level (int) + indented name, then 8 trailing numeric fields:
+#   total(f), calls(i), min(f), max(f), avg(f), pct_tot(f), pct_par(f), par_eff(f)
+# Matched from the right via decimal points rather than fixed columns, since
+# very long/deeply-nested names can overflow their fixed-width field in the
+# Fortran output.
+ROW_RE = re.compile(
+    r"^\s*(?P<level>\d+)\s+(?P<name>.+?)\s+"
+    r"(?P<total>\d+\.\d+)\s+(?P<calls>\d+)\s+"
+    r"(?P<min>\d+\.\d+)\s+(?P<max>\d+\.\d+)\s+(?P<avg>\d+\.\d+)\s+"
+    r"(?P<pct_tot>-?\d+\.\d+)\s+(?P<pct_par>-?\d+\.\d+)\s+(?P<par_eff>-?\d+\.\d+)\s*$"
+)
+
+HEADER_MARKER = "timer_name"
+
+
+def parse_timer_table(text: str) -> list[dict]:
+    lines = text.splitlines()
+
+    # Find the header row so we only parse the table, not incidental matches
+    # elsewhere in the log (there can be per-rank output for multiple ranks;
+    # we intentionally only read rank 0's log, so there is exactly one table).
+    start = None
+    for i, line in enumerate(lines):
+        if HEADER_MARKER in line and "total" in line and "pct_tot" in line:
+            start = i + 1
+            break
+
+    if start is None:
+        return []
+
+    rows = []
+    for line in lines[start:]:
+        if not line.strip():
+            # Native timer table is contiguous; a blank line ends it.
+            if rows:
+                break
+            continue
+        m = ROW_RE.match(line)
+        if not m:
+            # Table ended (next log section began)
+            if rows:
+                break
+            continue
+        rows.append(
+            {
+                "level": int(m.group("level")),
+                "name": m.group("name").strip(),
+                "total_s": float(m.group("total")),
+                "calls": int(m.group("calls")),
+                "min_s": float(m.group("min")),
+                "max_s": float(m.group("max")),
+                "avg_s": float(m.group("avg")),
+                "pct_tot": float(m.group("pct_tot")),
+                "pct_par": float(m.group("pct_par")),
+                "par_eff": float(m.group("par_eff")),
+            }
+        )
+    return rows
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("Usage: parse-mpas-timers.py <log-file> <output-json>", file=sys.stderr)
+        return 2
+
+    log_file, output_json = sys.argv[1], sys.argv[2]
+
+    try:
+        with open(log_file, "r", errors="replace") as f:
+            text = f.read()
+    except FileNotFoundError:
+        print(f"::error::log file not found: {log_file}", file=sys.stderr)
+        return 1
+
+    timers = parse_timer_table(text)
+
+    if not timers:
+        print(f"::warning::no timer table found in {log_file}", file=sys.stderr)
+
+    with open(output_json, "w") as f:
+        json.dump({"source_log": log_file, "timers": timers}, f, indent=2)
+
+    print(f"Parsed {len(timers)} timer rows from {log_file} -> {output_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/summarize-perf.py
+++ b/.github/scripts/summarize-perf.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Combine CPU and GPU MPAS timer JSON (from parse-mpas-timers.py) into:
+  1. A markdown comparison table (written to GITHUB_STEP_SUMMARY by the caller)
+  2. A single structured perf-result.json meant to be the durable record of
+     this run — this is the file a future history/graph step would append
+     to a time series from.
+
+All run metadata is read from environment variables so the workflow doesn't
+need a fragile positional CLI.
+
+Required env vars: CPU_JSON, GPU_JSON, OUT_JSON, OUT_MD
+Optional metadata env vars (all default to "unknown" if unset):
+  REF, SHA, RESOLUTION, RUN_DURATION, COMPILER, MPI,
+  CPU_RANKS, GPU_RANKS, RUNNER_GROUP, RUN_ID, RUN_URL, TARGET_ROUTINE
+"""
+
+import json
+import os
+
+
+def load_timers(path: str) -> dict:
+    with open(path) as f:
+        data = json.load(f)
+    # Keyed by timer name; if a name repeats (shouldn't, but be defensive)
+    # keep the first occurrence.
+    out = {}
+    for row in data.get("timers", []):
+        out.setdefault(row["name"], row)
+    return out
+
+
+def fmt(x, digits=3):
+    return f"{x:.{digits}f}"
+
+
+def main() -> int:
+    cpu_path = os.environ["CPU_JSON"]
+    gpu_path = os.environ["GPU_JSON"]
+    out_json = os.environ["OUT_JSON"]
+    out_md = os.environ["OUT_MD"]
+
+    meta = {
+        "ref": os.environ.get("REF", "unknown"),
+        "sha": os.environ.get("SHA", "unknown"),
+        "resolution": os.environ.get("RESOLUTION", "unknown"),
+        "run_duration": os.environ.get("RUN_DURATION", "unknown"),
+        "compiler": os.environ.get("COMPILER", "unknown"),
+        "mpi": os.environ.get("MPI", "unknown"),
+        "cpu_ranks": os.environ.get("CPU_RANKS", "unknown"),
+        "gpu_ranks": os.environ.get("GPU_RANKS", "unknown"),
+        "runner_group": os.environ.get("RUNNER_GROUP", "unknown"),
+        "run_id": os.environ.get("RUN_ID", "unknown"),
+        "run_url": os.environ.get("RUN_URL", ""),
+        "target_routine": os.environ.get("TARGET_ROUTINE", ""),
+    }
+
+    cpu_timers = load_timers(cpu_path)
+    gpu_timers = load_timers(gpu_path)
+
+    all_names = set(cpu_timers) | set(gpu_timers)
+    comparison = []
+    for name in all_names:
+        c = cpu_timers.get(name)
+        g = gpu_timers.get(name)
+        speedup = None
+        if c and g and g["total_s"] > 0:
+            speedup = c["total_s"] / g["total_s"]
+        comparison.append(
+            {
+                "name": name,
+                "cpu_total_s": c["total_s"] if c else None,
+                "cpu_calls": c["calls"] if c else None,
+                "gpu_total_s": g["total_s"] if g else None,
+                "gpu_calls": g["calls"] if g else None,
+                "speedup_cpu_over_gpu": speedup,
+            }
+        )
+
+    # Sort by whichever side has the larger total time, descending, so the
+    # most expensive routines surface first regardless of which side is slower.
+    def sort_key(row):
+        vals = [v for v in (row["cpu_total_s"], row["gpu_total_s"]) if v is not None]
+        return max(vals) if vals else 0.0
+
+    comparison.sort(key=sort_key, reverse=True)
+
+    result = {
+        "meta": meta,
+        "comparison": comparison,
+        "cpu_timers_full": list(cpu_timers.values()),
+        "gpu_timers_full": list(gpu_timers.values()),
+    }
+
+    with open(out_json, "w") as f:
+        json.dump(result, f, indent=2)
+
+    # --- Markdown summary ---
+    lines = []
+    lines.append("## CPU vs GPU performance (native MPAS timers)")
+    lines.append("")
+    lines.append(
+        f"- **Ref:** `{meta['ref']}` @ `{meta['sha'][:12]}`  "
+        f"- **Resolution:** {meta['resolution']}  "
+        f"- **Run duration:** {meta['run_duration']}"
+    )
+    lines.append(
+        f"- **Compiler/MPI:** {meta['compiler']}/{meta['mpi']}  "
+        f"- **Ranks:** CPU={meta['cpu_ranks']}, GPU={meta['gpu_ranks']}  "
+        f"- **Runner group:** {meta['runner_group']} (same hardware, both legs)"
+    )
+    if meta["target_routine"]:
+        lines.append(f"- **Branch target routine:** `{meta['target_routine']}`")
+    lines.append("")
+    lines.append(
+        "Wall-clock time per named MPAS timer. GPU-only rows (e.g. "
+        "`[ACC_data_xfer]`) have no CPU counterpart and no speedup figure. "
+        "This is not GPU kernel-level granularity — see the routine's own "
+        "notes for a future Nsight-based pass."
+    )
+    lines.append("")
+    lines.append("| Timer | CPU total (s) | GPU total (s) | Speedup (CPU/GPU) |")
+    lines.append("|---|---:|---:|---:|")
+
+    MAX_ROWS = 30
+    shown = comparison[:MAX_ROWS]
+    for row in shown:
+        marker = " **\u2190 target**" if row["name"] == meta["target_routine"] else ""
+        cpu_s = fmt(row["cpu_total_s"]) if row["cpu_total_s"] is not None else "\u2014"
+        gpu_s = fmt(row["gpu_total_s"]) if row["gpu_total_s"] is not None else "\u2014"
+        speedup = f"{row['speedup_cpu_over_gpu']:.2f}\u00d7" if row["speedup_cpu_over_gpu"] else "\u2014"
+        lines.append(f"| `{row['name']}`{marker} | {cpu_s} | {gpu_s} | {speedup} |")
+
+    if len(comparison) > MAX_ROWS:
+        lines.append("")
+        lines.append(
+            f"_{len(comparison) - MAX_ROWS} more timer(s) omitted from this table; "
+            "full data is in the uploaded perf-result.json artifact._"
+        )
+
+    cpu_total = cpu_timers.get("total time", {}).get("total_s")
+    gpu_total = gpu_timers.get("total time", {}).get("total_s")
+    if cpu_total and gpu_total:
+        lines.append("")
+        lines.append(
+            f"**Overall wall time:** CPU {fmt(cpu_total)}s vs GPU {fmt(gpu_total)}s "
+            f"({cpu_total / gpu_total:.2f}\u00d7)"
+        )
+
+    with open(out_md, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+    print(f"Wrote {out_json} and {out_md} ({len(comparison)} timer rows compared)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/_test-perf.yml
+++ b/.github/workflows/_test-perf.yml
@@ -1,0 +1,263 @@
+# Reusable workflow: CPU vs GPU performance comparison.
+#
+# Builds MPAS-A with NVHPC once without OpenACC (CPU) and once with OpenACC
+# (GPU), runs both on the *same* CIRRUS runner group so core count, memory,
+# and node hardware are identical between legs — the only variable is the
+# accelerator. Comparison uses MPAS-A's native per-routine timer table
+# (on by default; see .github/scripts/parse-mpas-timers.py), so no source
+# changes are needed and results are as granular as the model's own
+# instrumentation (e.g. atm_advance_acoustic_step, atm_compute_dyn_tend).
+#
+# This is wall-clock timing only — not GPU kernel-level granularity. A
+# Nsight-based pass for true kernel times is a natural follow-up once this
+# baseline is in use.
+#
+# Security: self-hosted CIRRUS runners. Callers must use workflow_dispatch
+# only, same as _test-gpu.yml and _test-bfb.yml's gpu=true path.
+
+name: _test-perf
+
+permissions:
+  contents: read
+  actions: write
+
+on:
+  workflow_call:
+    inputs:
+      mpi:
+        description: 'MPI implementation (mpich, openmpi)'
+        required: true
+        type: string
+      runner-group:
+        description: 'Runner group used for BOTH the CPU and GPU legs (same hardware is the point)'
+        required: false
+        type: string
+        default: 'CIRRUS-32x256-A10'
+      resolution:
+        description: 'Test case resolution (see RELEASE_TESTDATA_* in ci-config.env)'
+        required: false
+        type: string
+        default: '120km'
+      run-duration:
+        description: 'config_run_duration override (D_HH:MM:SS)'
+        required: false
+        type: string
+        default: '0_00:12:00'
+      cpu-ranks:
+        description: 'MPI rank count for the CPU leg'
+        required: false
+        type: string
+        default: '32'
+      gpu-ranks:
+        description: 'MPI rank count for the GPU leg (typically 1 per GPU on the node)'
+        required: false
+        type: string
+        default: '1'
+      run-timeout:
+        description: 'Run step timeout in minutes (applies to both legs)'
+        required: false
+        type: string
+        default: '30'
+      target-routine:
+        description: >
+          Optional MPAS timer name to call out in the summary (e.g. the routine
+          a hack26_* branch is porting, such as atm_advance_acoustic_step).
+          Purely cosmetic — has no effect on what is measured.
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  config:
+    name: Resolve Config
+    runs-on: ubuntu-latest
+    outputs:
+      image-cpu: ${{ steps.cpu-container.outputs.image }}
+      image-gpu: ${{ steps.gpu-container.outputs.image }}
+      mpas-version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            .github
+            src/core_atmosphere/Registry.xml
+          sparse-checkout-cone-mode: false
+
+      - uses: ./.github/actions/resolve-container
+        id: cpu-container
+        with:
+          compiler: nvhpc
+          mpi: ${{ inputs.mpi }}
+
+      - uses: ./.github/actions/resolve-container
+        id: gpu-container
+        with:
+          compiler: nvhpc
+          mpi: ${{ inputs.mpi }}
+          gpu: cuda
+
+      - uses: ./.github/actions/mpas-version
+        id: version
+
+  build:
+    needs: config
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - leg: cpu
+            openacc: false
+            image: ${{ needs.config.outputs.image-cpu }}
+          - leg: gpu
+            openacc: true
+            image: ${{ needs.config.outputs.image-gpu }}
+    name: Build (${{ matrix.leg }})
+    runs-on:
+      group: ${{ inputs.runner-group }}
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: 'true'
+
+      - name: Build MPAS-A (double precision${{ matrix.openacc && ', OpenACC' || '' }})
+        uses: ./.github/actions/build-mpas
+        with:
+          compiler: nvhpc
+          use-pio: 'false'
+          openacc: ${{ matrix.openacc && 'true' || 'false' }}
+          precision: double
+          build-timeout: '45'
+
+      - name: Upload executable
+        uses: actions/upload-artifact@v6
+        with:
+          name: exe-perf-${{ matrix.leg }}-${{ inputs.mpi }}
+          path: atmosphere_model
+          retention-days: 1
+
+  run:
+    needs: [config, build]
+    if: ${{ needs.build.result == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - leg: cpu
+            openacc: false
+            image: ${{ needs.config.outputs.image-cpu }}
+            ranks: ${{ inputs.cpu-ranks }}
+          - leg: gpu
+            openacc: true
+            image: ${{ needs.config.outputs.image-gpu }}
+            ranks: ${{ inputs.gpu-ranks }}
+    name: Run (${{ matrix.leg }})
+    runs-on:
+      group: ${{ inputs.runner-group }}
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check GPU availability
+        if: ${{ matrix.openacc }}
+        shell: bash
+        run: |
+          echo "=== GPU Information ==="
+          nvidia-smi || echo "::warning::nvidia-smi failed"
+
+      - name: Download executable
+        uses: actions/download-artifact@v7
+        with:
+          name: exe-perf-${{ matrix.leg }}-${{ inputs.mpi }}
+
+      - name: Run MPAS-A
+        uses: ./.github/actions/run-mpas
+        with:
+          executable: ./atmosphere_model
+          num-procs: '${{ matrix.ranks }}'
+          resolution: ${{ inputs.resolution }}
+          run-duration: ${{ inputs.run-duration }}
+          run-timeout: ${{ inputs.run-timeout }}
+          mpi-impl: ${{ inputs.mpi }}
+          working-dir: run-perf-${{ matrix.leg }}
+          strict-exit-check: 'false'
+
+      - name: Parse MPAS timers
+        uses: ./.github/actions/parse-mpas-timers
+        with:
+          log-dir: run-perf-${{ matrix.leg }}
+          output-file: mpas-timers-${{ matrix.leg }}.json
+
+      - name: Upload timer JSON
+        uses: actions/upload-artifact@v6
+        with:
+          name: perf-timers-${{ matrix.leg }}
+          path: mpas-timers-${{ matrix.leg }}.json
+          retention-days: 1
+
+  summarize:
+    needs: [config, run]
+    if: ${{ !cancelled() && needs.run.result == 'success' }}
+    name: Summarize CPU vs GPU
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github
+
+      - name: Download timer JSON (both legs)
+        uses: actions/download-artifact@v7
+        with:
+          pattern: perf-timers-*
+          path: perf-timers
+          merge-multiple: true
+
+      - name: Combine and summarize
+        env:
+          CPU_JSON: perf-timers/mpas-timers-cpu.json
+          GPU_JSON: perf-timers/mpas-timers-gpu.json
+          OUT_JSON: perf-result.json
+          OUT_MD: perf-summary.md
+          REF: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          RESOLUTION: ${{ inputs.resolution }}
+          RUN_DURATION: ${{ inputs.run-duration }}
+          COMPILER: nvhpc
+          MPI: ${{ inputs.mpi }}
+          CPU_RANKS: ${{ inputs.cpu-ranks }}
+          GPU_RANKS: ${{ inputs.gpu-ranks }}
+          RUNNER_GROUP: ${{ inputs.runner-group }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TARGET_ROUTINE: ${{ inputs.target-routine }}
+        run: |
+          python3 .github/scripts/summarize-perf.py
+          cat perf-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload perf result
+        uses: actions/upload-artifact@v6
+        with:
+          name: perf-result-${{ github.run_id }}
+          path: perf-result.json
+          retention-days: 90
+
+  cleanup:
+    needs: [run, summarize]
+    if: always()
+    runs-on: ubuntu-latest
+    name: Cleanup
+    steps:
+      - name: Delete temporary artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+            --paginate --jq '.artifacts[] | select(.name | startswith("exe-perf-") or startswith("perf-timers-")) | .id' \
+          | while read id; do
+              gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id || true
+            done || true

--- a/.github/workflows/perf-cpu-vs-gpu.yml
+++ b/.github/workflows/perf-cpu-vs-gpu.yml
@@ -1,0 +1,62 @@
+# CPU vs GPU performance comparison on CIRRUS-32x256-A10.
+#
+# Run this from whichever branch you want measured — e.g. a hack26_* routine
+# branch — by picking that branch in the "Run workflow" ref dropdown. Both
+# legs build/run on the same runner group, so the only difference between
+# them is CPU vs GPU (NVHPC + OpenACC).
+#
+# workflow_dispatch only: self-hosted CIRRUS runners must never trigger on
+# push/pull_request (fork / unreviewed-code risk), same as the rest of the
+# GPU test suite.
+
+name: "Perf: CPU vs GPU (NVHPC)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      mpi:
+        description: MPI implementation
+        required: true
+        default: mpich
+        type: choice
+        options:
+          - mpich
+          - openmpi
+      resolution:
+        description: Test case resolution (see RELEASE_TESTDATA_* in ci-config.env)
+        required: false
+        default: '120km'
+        type: string
+      run_duration:
+        description: config_run_duration (D_HH:MM:SS)
+        required: false
+        default: '0_00:12:00'
+        type: string
+      cpu_ranks:
+        description: MPI rank count for the CPU leg
+        required: false
+        default: '32'
+        type: string
+      gpu_ranks:
+        description: MPI rank count for the GPU leg (1 per GPU on the node)
+        required: false
+        default: '1'
+        type: string
+      target_routine:
+        description: >
+          Optional: MPAS timer name to call out in the summary (e.g.
+          atm_advance_acoustic_step). Cosmetic only.
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  perf:
+    uses: ./.github/workflows/_test-perf.yml
+    with:
+      mpi: ${{ inputs.mpi }}
+      resolution: ${{ inputs.resolution }}
+      run-duration: ${{ inputs.run_duration }}
+      cpu-ranks: ${{ inputs.cpu_ranks }}
+      gpu-ranks: ${{ inputs.gpu_ranks }}
+      target-routine: ${{ inputs.target_routine }}


### PR DESCRIPTION
First try at CPU vs GPU performance testing using a dedicated CIRRUS runner (32 cores / 256GB / 1x A10 each).

Initially, both versions are built with nvhpc (but might try different cpu builds in the future). The timing is parsed from log.atmosphere.0000.out, from the summary timing table. Both CPU and GPU builds can probably be optimized, but this is where we're starting. The model for this performance comparison was the test_bfb template. 
