### PR TITLE
CI: don't require new ensemble generation for bugfix versions

### DIFF
--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -70,7 +70,8 @@ Current tags: `testdata-240km-v1`, `testdata-120km-v1` (see `RELEASE_TESTDATA_*`
 - **`develop`** — integration branch matching upstream MPAS-Dev/MPAS-Model `develop` (feature PRs land here first).
 - **`PRtest-*`** — temporary branches for testing contributor PRs: base on **`develop`**, overlay CI from `master`, cherry-pick the PR commit(s), push. Auto-runs **CPU ECT subsets** (and BFB callers). Prefer this over `hackathon-*` for PR validation.
 - **`hackathon-*`** — same auto-CI as `PRtest-*` (kept for hackathon experiments).
-- **GPU ECT** stays **`workflow_dispatch` only** (see Security). CPU BFB callers also run on push to `hackathon`, `hackathon/**`, `hackathon-*`, `PRtest-*`, or legacy `feature-ci-bfb`.
+- **`hotfix-*`** / **`hotfix/**`** — same auto-CI as `PRtest-*`, so gitflow hotfix branches (e.g. `hotfix-v8.4.2`) are tested without renaming them. A patch bump reuses the series ECT data (`ect-v8.4`); see Test Data.
+- **GPU ECT** stays **`workflow_dispatch` only** (see Security). CPU BFB callers run on push to `hackathon`, `hackathon/**`, `hackathon-*`, `PRtest-*`, `hotfix-*`, `hotfix/**`, and on PRs targeting `master`, `develop`, or a `hotfix` branch.
 
 ## Workflow Architecture
 
@@ -81,7 +82,7 @@ Each compiler+MPI combination has a thin caller workflow that invokes a reusable
 - **CPU subsets** call `_test-compiler.yml` with `compiler` and `mpi` inputs
 - **GPU subsets** call `_test-gpu.yml` with `mpi` input (always NVHPC)
 
-**MPICH callers** (`test-gcc-mpich`, `test-intel-mpich`, `test-nvhpc-mpich`) run on push/PR to `master`/`develop` and to **`PRtest-*`** / **`hackathon-*`**.
+**MPICH callers** (`test-gcc-mpich`, `test-intel-mpich`, `test-nvhpc-mpich`) run on push/PR to `master`/`develop` and to **`PRtest-*`** / **`hackathon-*`** / **`hotfix-*`**.
 **compile-nvhpc-cuda-mpich** (NVHPC + OpenACC compile-only on GitHub-hosted runners) also runs on push/PR to those branches.
 **OpenMPI CPU callers** (`test-*-openmpi`) stay **`workflow_dispatch` only** (optional; OpenMPI regressions).
 **GPU ECT callers** (`test-gpu-mpich`, `test-gpu-openmpi`) are **`workflow_dispatch` only** (self-hosted CIRRUS).

--- a/.github/AGENT_GUIDE.md
+++ b/.github/AGENT_GUIDE.md
@@ -58,7 +58,7 @@ tests/                           # pFUnit test infrastructure (repo root)
 
 Test case archives, ECT ensemble summary files, and ECT spin-up restarts are stored as **GitHub release assets on this repository** (`NCAR/MPAS-Model-CI`). Each asset is versioned by its own release tag (independent of the others).
 
-Current tags: `testdata-240km-v1`, `testdata-120km-v1` (see `RELEASE_TESTDATA_*` in `ci-config.env`), plus `ect-v{MPAS_VERSION}` for ECT data — its tag is derived at runtime from `src/core_atmosphere/Registry.xml` via the `mpas-version` composite action, not from `ci-config.env`.
+Current tags: `testdata-240km-v1`, `testdata-120km-v1` (see `RELEASE_TESTDATA_*` in `ci-config.env`), plus `ect-v{MAJOR.MINOR}` for ECT data — its tag is derived at runtime from `src/core_atmosphere/Registry.xml` via the `mpas-version` composite action, not from `ci-config.env`. One ECT release serves every patch release in a series (`ect-v8.4` covers 8.4.0, 8.4.1, 8.4.2, …), so a hotfix version bump does not require regenerating the 200-member ensemble.
 
 **Adding a new test case:** build the archive (`{resolution}.tar.gz`), create a release (`gh release create … --repo NCAR/MPAS-Model-CI`), attach the asset, then set `RELEASE_TESTDATA_{RES}` in `ci-config.env` (resolution uppercased with `-` → `_` in the variable name, e.g. `120KM`).
 
@@ -127,7 +127,7 @@ Key settings:
 - `OPENMPI_RUN_FLAGS` — extra `mpirun` flags for OpenMPI in containers (root + oversubscribe). MPICH needs no equivalent. Comment in `ci-config.env` lists the consumer sites for adding analogous flags later.
 - `RELEASE_TESTDATA_{RES}` — GitHub release tag for `{resolution}.tar.gz` test archives (`RES` uppercased, `-` → `_`)
 - `ECT_*` — ECT resolution, perturbation, summary/restart filenames, excluded-vars path, etc.
-- The ECT release tag (`ect-v{MPAS_VERSION}`) is **not** stored here; it is derived at runtime from `src/core_atmosphere/Registry.xml` by the `mpas-version` composite action (see below). This guarantees the writer (`ect-ensemble-gen.yml`) and readers (`_test-compiler.yml`, `_test-gpu.yml`, `ect-test.yml`, `validate-ect`) can never drift apart.
+- The ECT release tag (`ect-v{MAJOR.MINOR}`) is **not** stored here; it is derived at runtime from `src/core_atmosphere/Registry.xml` by the `mpas-version` composite action (see below). This guarantees the writer (`ect-ensemble-gen.yml`) and readers (`_test-compiler.yml`, `_test-gpu.yml`, `ect-test.yml`, `validate-ect`) can never drift apart. Because the tag drops the patch component, patch releases within a series share one ensemble.
 - `PYCECT_TAG` — PyCECT git tag for `validate-ect`
 - `BFB_*` — default resolution, duration, and run timeout for bit-for-bit workflows; per-variant overrides live in the `variants` JSON passed to `_test-bfb.yml`
 
@@ -187,10 +187,10 @@ Runs a standard MPAS-A case: uses `download-testdata`, copies the extracted tree
 Runs perturbed ensemble members for ECT. Requires explicit `run-duration` and `run-timeout` inputs. Sources `ci-config.env` for ECT settings (perturbation variable/magnitude, excluded-vars path, etc.). Activates conda, installs netCDF4/numpy, loops through members applying theta perturbation, runs the model, and trims history files. Supports restart mode.
 
 ### validate-ect
-Takes a required `mpas-version` input and builds the release tag as `ect-v{mpas-version}`. Sources `ci-config.env` for summary filename, time slice, and PyCECT tag (no `RELEASE_ECT` lookup). Downloads the summary from the matching release URL, installs deps, clones PyCECT at `PYCECT_TAG`, runs validation, and writes an enriched result file with dimension metadata.
+Takes a required `ect-tag` input (the release tag emitted by the `mpas-version` action). Sources `ci-config.env` for summary filename, time slice, and PyCECT tag (no `RELEASE_ECT` lookup). Downloads the summary from the matching release URL, installs deps, clones PyCECT at `PYCECT_TAG`, runs validation, and writes an enriched result file with dimension metadata.
 
 ### mpas-version
-Reads the MPAS version string from `src/core_atmosphere/Registry.xml` using `python3` + `xml.etree.ElementTree`. Strict — fails the workflow if the file is missing or the `<registry version="…">` attribute cannot be parsed (no silent `unknown` fallback). Single source of truth for the `ect-v{MPAS_VERSION}` release tag used by `_test-compiler.yml`, `_test-gpu.yml`, `ect-test.yml`, `ect-ensemble-gen.yml`, and `validate-ect`. Workflows that consume the version typically extract it once in their `config` job and pass it to downstream jobs as a job output.
+Reads the MPAS version string from `src/core_atmosphere/Registry.xml` using `python3` + `xml.etree.ElementTree`. Strict — fails the workflow if the file is missing, the `<registry version="…">` attribute cannot be parsed (no silent `unknown` fallback), or the version has no `MAJOR.MINOR` prefix. Outputs `version` (`8.4.2`), `version-series` (`8.4`), and `ect-tag` (`ect-v8.4`). Single source of truth for the ECT release tag used by `_test-compiler.yml`, `_test-gpu.yml`, `ect-test.yml`, `ect-ensemble-gen.yml`, and `validate-ect` — consumers pass `ect-tag` through rather than rebuilding the tag, so the writer and readers cannot drift. Workflows extract it once in their `config` job and pass it to downstream jobs as a job output.
 
 ### print-mpas-logs
 Dumps MPAS per-rank log files (`log.atmosphere.<rank>.out` / `.err`) to the workflow log inside collapsible `::group::` blocks so the GitHub Actions UI gives one expandable section per file. Inputs: `log-dir` (required), `pattern` (default `log.atmosphere.*`), `max-lines` (default empty = full file; set to N to `tail -n N`). Read-only and never fails on its own — call sites should add `if: always()` so logs print on both success and failure. Already wired into `run-mpas` (reads from the run working dir) and `run-perturb-mpas` (reads from `output-dir`, where the per-member loop has copied each rank's `.out` and `.err` before tearing down the rundir).

--- a/.github/actions/mpas-version/action.yml
+++ b/.github/actions/mpas-version/action.yml
@@ -1,6 +1,7 @@
 name: 'Get MPAS Version'
 description: >
-  Read the MPAS version string from src/core_atmosphere/Registry.xml.
+  Read the MPAS version string from src/core_atmosphere/Registry.xml and
+  derive the major.minor series and ECT data release tag from it.
   Strict — fails the workflow if the file is missing or the version
   attribute cannot be parsed (no silent "unknown" fallback).
 
@@ -14,6 +15,12 @@ outputs:
   version:
     description: 'MPAS version string (e.g., 8.4.0)'
     value: ${{ steps.extract.outputs.version }}
+  version-series:
+    description: 'Major.minor series (e.g., 8.4)'
+    value: ${{ steps.extract.outputs.version-series }}
+  ect-tag:
+    description: 'ECT data release tag for this series (e.g., ect-v8.4)'
+    value: ${{ steps.extract.outputs.ect-tag }}
 
 runs:
   using: 'composite'
@@ -23,6 +30,7 @@ runs:
       run: |
         python3 - "${{ inputs.registry-path }}" <<'PYEOF'
         import os
+        import re
         import sys
         import xml.etree.ElementTree as ET
 
@@ -41,7 +49,19 @@ runs:
             print(f"::error::No version attribute on <registry> in {path}")
             sys.exit(1)
 
+        # ECT data is shared across a major.minor series: ect-v8.4 serves
+        # 8.4.0, 8.4.1, ... so patch releases don't need a new 200-member
+        # ensemble. Regenerate only when the series changes.
+        match = re.match(r'^(\d+)\.(\d+)', version)
+        if not match:
+            print(f"::error::Cannot derive major.minor series from version '{version}'")
+            sys.exit(1)
+        series = f"{match.group(1)}.{match.group(2)}"
+        ect_tag = f"ect-v{series}"
+
         with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
             f.write(f"version={version}\n")
-        print(f"MPAS version: {version}")
+            f.write(f"version-series={series}\n")
+            f.write(f"ect-tag={ect_tag}\n")
+        print(f"MPAS version: {version} (series {series}, ECT tag {ect_tag})")
         PYEOF

--- a/.github/actions/validate-ect/action.yml
+++ b/.github/actions/validate-ect/action.yml
@@ -12,8 +12,8 @@ inputs:
   label:
     description: 'Human-readable label for log annotations (e.g. gcc/mpich3/smiol/4proc)'
     required: true
-  mpas-version:
-    description: 'MPAS version string (used to build the ect-v{version} release tag)'
+  ect-tag:
+    description: 'ECT data release tag (from the mpas-version action, e.g. ect-v8.4)'
     required: true
   dimensions:
     description: 'Multi-line key=value pairs describing this test combination (written into result file)'
@@ -42,12 +42,12 @@ runs:
         fi
         source "${CI_CONFIG}"
 
-        # ECT release tag is derived from the MPAS version (passed in),
-        # not stored in ci-config.env. See .github/actions/mpas-version.
+        # ECT release tag is passed in, not stored in ci-config.env.
+        # See .github/actions/mpas-version.
         echo "summary-file=${ECT_SUMMARY_FILE}" >> $GITHUB_OUTPUT
         echo "pycect-tag=${PYCECT_TAG}" >> $GITHUB_OUTPUT
         echo "pycect-commit=${PYCECT_COMMIT}" >> $GITHUB_OUTPUT
-        echo "release-tag=ect-v${{ inputs.mpas-version }}" >> $GITHUB_OUTPUT
+        echo "release-tag=${{ inputs.ect-tag }}" >> $GITHUB_OUTPUT
 
     - name: Install PyCECT dependencies
       shell: bash

--- a/.github/ci-config.env
+++ b/.github/ci-config.env
@@ -90,13 +90,15 @@ RELEASE_TESTDATA_240KM=testdata-240km-v3
 RELEASE_TESTDATA_120KM=testdata-120km-v2
 
 # ── ECT release tag ──────────────────────────────
-# The ECT release tag (ect-v{MPAS_VERSION}) is derived at runtime from
+# The ECT release tag (ect-v{MAJOR.MINOR}, e.g. ect-v8.4) is derived at runtime from
 # src/core_atmosphere/Registry.xml via the .github/actions/mpas-version
 # composite action. There is no manual tag here — that ensures readers
 # (validate-ect, _test-compiler, _test-gpu, ect-test) and the writer
 # (ect-ensemble-gen) cannot drift out of sync.
 #
-# To publish ECT data for a new MPAS version, run ect-ensemble-gen.yml.
+# One release serves every patch release in a series, so a version bump
+# from 8.4.1 to 8.4.2 reuses ect-v8.4. Run ect-ensemble-gen.yml only when
+# the series changes (8.4 -> 8.5) or the ensemble is invalidated.
 
 
 # ── ECT configuration ────────────────────────────

--- a/.github/workflows/_test-compiler.yml
+++ b/.github/workflows/_test-compiler.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.container.outputs.image }}
-      mpas-version: ${{ steps.version.outputs.version }}
+      ect-tag: ${{ steps.version.outputs.ect-tag }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -136,7 +136,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
+          key: ect-spinup-restart-${{ needs.config.outputs.ect-tag }}-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Download spin-up restart
         if: steps.download.outcome == 'success'
@@ -145,7 +145,7 @@ jobs:
         run: |
           source .github/ci-config.env
           RESTART="${ECT_RESTART_FILE}"
-          RELEASE_TAG="ect-v${{ needs.config.outputs.mpas-version }}"
+          RELEASE_TAG="${{ needs.config.outputs.ect-tag }}"
 
           if [ -f "spinup-restart.nc" ]; then
             echo "Using cached restart file"
@@ -223,7 +223,7 @@ jobs:
         with:
           history-dir: ect-test-files
           label: ${{ inputs.compiler }}/${{ inputs.mpi }}/smiol
-          mpas-version: ${{ needs.config.outputs.mpas-version }}
+          ect-tag: ${{ needs.config.outputs.ect-tag }}
           dimensions: |
             compiler=${{ inputs.compiler }}
             mpi=${{ inputs.mpi }}

--- a/.github/workflows/_test-gpu.yml
+++ b/.github/workflows/_test-gpu.yml
@@ -37,7 +37,7 @@ jobs:
     outputs:
       image: ${{ steps.container.outputs.image }}
       image-gpu: ${{ steps.gpu-container.outputs.image }}
-      mpas-version: ${{ steps.version.outputs.version }}
+      ect-tag: ${{ steps.version.outputs.ect-tag }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -152,7 +152,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
+          key: ect-spinup-restart-${{ needs.config.outputs.ect-tag }}-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Download spin-up restart
         if: steps.download.outcome == 'success'
@@ -161,7 +161,7 @@ jobs:
         run: |
           source .github/ci-config.env
           RESTART="${ECT_RESTART_FILE}"
-          RELEASE_TAG="ect-v${{ needs.config.outputs.mpas-version }}"
+          RELEASE_TAG="${{ needs.config.outputs.ect-tag }}"
 
           if [ -f "spinup-restart.nc" ]; then
             echo "Using cached restart file"
@@ -238,7 +238,7 @@ jobs:
         with:
           history-dir: ect-test-files
           label: nvhpc/${{ inputs.mpi }}/cuda/smiol
-          mpas-version: ${{ needs.config.outputs.mpas-version }}
+          ect-tag: ${{ needs.config.outputs.ect-tag }}
           dimensions: |
             compiler=nvhpc
             mpi=${{ inputs.mpi }}

--- a/.github/workflows/bfb-decomp.yml
+++ b/.github/workflows/bfb-decomp.yml
@@ -6,7 +6,9 @@ name: "BFB: Decomposition (1 vs 4 ranks)"
 on:
   workflow_dispatch:
   push:
-    branches: [hackathon, 'hackathon/**', 'hackathon-*', 'PRtest-*', feature-ci-bfb]
+    branches: [hackathon, 'hackathon/**', 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
+  pull_request:
+    branches: [master, develop, 'hotfix-*', 'hotfix/**']
 
 jobs:
   test:

--- a/.github/workflows/bfb-io.yml
+++ b/.github/workflows/bfb-io.yml
@@ -6,7 +6,9 @@ name: "BFB: I/O (SMIOL vs PIO)"
 on:
   workflow_dispatch:
   push:
-    branches: [hackathon, 'hackathon/**', 'hackathon-*', 'PRtest-*', feature-ci-bfb]
+    branches: [hackathon, 'hackathon/**', 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
+  pull_request:
+    branches: [master, develop, 'hotfix-*', 'hotfix/**']
 
 jobs:
   test:

--- a/.github/workflows/compile-nvhpc-cuda-mpich.yml
+++ b/.github/workflows/compile-nvhpc-cuda-mpich.yml
@@ -9,9 +9,9 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    branches: [master, develop, 'hackathon-*', 'PRtest-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
   pull_request:
-    branches: [master, develop, 'hackathon-*', 'PRtest-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
 
 jobs:
   config:

--- a/.github/workflows/ect-ensemble-gen.yml
+++ b/.github/workflows/ect-ensemble-gen.yml
@@ -102,6 +102,8 @@ jobs:
     outputs:
       mpas-version: ${{ steps.version.outputs.mpas-version }}
       mpas-commit: ${{ steps.version.outputs.mpas-commit }}
+      version-series: ${{ steps.mpas_version.outputs.version-series }}
+      ect-tag: ${{ steps.mpas_version.outputs.ect-tag }}
     container:
       image: ${{ needs.prepare.outputs.container-image }}
 
@@ -170,7 +172,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
+          key: ect-spinup-restart-${{ needs.build.outputs.ect-tag }}-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Download executable
         if: steps.cache.outputs.cache-hit != 'true'
@@ -212,7 +214,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
+          key: ect-spinup-restart-${{ needs.build.outputs.ect-tag }}-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Upload restart artifact
         uses: actions/upload-artifact@v6
@@ -463,9 +465,9 @@ jobs:
           fi
 
   #===========================================================================
-  # PUBLISH RESTART: Upload spin-up restart to ect-v{MPAS_VERSION}
+  # PUBLISH RESTART: Upload spin-up restart to ect-v{MAJOR.MINOR}
   # Runs after spinup regardless of ensemble/summary outcome.
-  # Auto-creates the release (tagged by MPAS version) if it doesn't exist.
+  # Auto-creates the release (tagged by version series) if it doesn't exist.
   #===========================================================================
   publish-restart:
     needs: [build, spinup]
@@ -491,14 +493,15 @@ jobs:
         run: |
           source .github/ci-config.env
           VERSION="${{ needs.build.outputs.mpas-version }}"
-          TAG="ect-v${VERSION}"
+          SERIES="${{ needs.build.outputs.version-series }}"
+          TAG="${{ needs.build.outputs.ect-tag }}"
 
           # Create release if it doesn't exist
           if ! gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             echo "Creating release ${TAG}..."
             gh release create "${TAG}" --repo "${GITHUB_REPOSITORY}" \
-              --title "ECT data (MPAS v${VERSION})" \
-              --notes "ECT ensemble summary and spin-up restart for MPAS v${VERSION}. Updated automatically by the ect-ensemble-gen workflow."
+              --title "ECT data (MPAS v${SERIES}.x)" \
+              --notes "ECT ensemble summary and spin-up restart shared by all MPAS v${SERIES}.x releases. Generated from v${VERSION}. Updated automatically by the ect-ensemble-gen workflow."
           fi
 
           RESTART_NAME="${ECT_RESTART_FILE}"
@@ -514,9 +517,9 @@ jobs:
           echo "  File: ${RESTART_NAME}.gz ($(du -h "${RESTART_NAME}.gz" | cut -f1))"
 
   #===========================================================================
-  # PUBLISH SUMMARY: Upload ensemble summary to ect-v{MPAS_VERSION}
+  # PUBLISH SUMMARY: Upload ensemble summary to ect-v{MAJOR.MINOR}
   # Only runs when summary generation succeeds.
-  # Auto-creates the release (tagged by MPAS version) if it doesn't exist.
+  # Auto-creates the release (tagged by version series) if it doesn't exist.
   #===========================================================================
   publish-summary:
     needs: [build, generate-summary]
@@ -543,14 +546,15 @@ jobs:
         run: |
           source .github/ci-config.env
           VERSION="${{ needs.build.outputs.mpas-version }}"
-          TAG="ect-v${VERSION}"
+          SERIES="${{ needs.build.outputs.version-series }}"
+          TAG="${{ needs.build.outputs.ect-tag }}"
 
           # Create release if it doesn't exist
           if ! gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             echo "Creating release ${TAG}..."
             gh release create "${TAG}" --repo "${GITHUB_REPOSITORY}" \
-              --title "ECT data (MPAS v${VERSION})" \
-              --notes "ECT ensemble summary and spin-up restart for MPAS v${VERSION}. Updated automatically by the ect-ensemble-gen workflow."
+              --title "ECT data (MPAS v${SERIES}.x)" \
+              --notes "ECT ensemble summary and spin-up restart shared by all MPAS v${SERIES}.x releases. Generated from v${VERSION}. Updated automatically by the ect-ensemble-gen workflow."
           fi
 
           SUMMARY_NAME="${{ needs.generate-summary.outputs.summary-name }}"

--- a/.github/workflows/ect-test.yml
+++ b/.github/workflows/ect-test.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.container.outputs.image }}
-      mpas-version: ${{ steps.version.outputs.version }}
+      ect-tag: ${{ steps.version.outputs.ect-tag }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -124,7 +124,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
+          key: ect-spinup-restart-${{ needs.config.outputs.ect-tag }}-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Download spin-up restart
         id: restart
@@ -132,7 +132,7 @@ jobs:
         run: |
           source .github/ci-config.env
           RESTART="${ECT_RESTART_FILE}"
-          RELEASE_TAG="ect-v${{ needs.config.outputs.mpas-version }}"
+          RELEASE_TAG="${{ needs.config.outputs.ect-tag }}"
 
           if [ -f "spinup-restart.nc" ]; then
             echo "Using cached restart file"
@@ -213,7 +213,7 @@ jobs:
         with:
           history-dir: ect-test-files
           label: gcc/openmpi/ect-standalone
-          mpas-version: ${{ needs.config.outputs.mpas-version }}
+          ect-tag: ${{ needs.config.outputs.ect-tag }}
 
   #===========================================================================
   # CLEANUP

--- a/.github/workflows/test-gcc-mpich.yml
+++ b/.github/workflows/test-gcc-mpich.yml
@@ -6,9 +6,9 @@ name: "GNU+MPICH (CPU)"
 on:
   workflow_dispatch:
   push:
-    branches: [master, develop, 'hackathon-*', 'PRtest-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
   pull_request:
-    branches: [master, develop, 'hackathon-*', 'PRtest-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
 
 jobs:
   test:

--- a/.github/workflows/test-intel-mpich.yml
+++ b/.github/workflows/test-intel-mpich.yml
@@ -6,9 +6,9 @@ name: "Intel+MPICH (CPU)"
 on:
   workflow_dispatch:
   push:
-    branches: [master, develop, 'hackathon-*', 'PRtest-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
   pull_request:
-    branches: [master, develop, 'hackathon-*', 'PRtest-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
 
 jobs:
   test:

--- a/.github/workflows/test-nvhpc-mpich.yml
+++ b/.github/workflows/test-nvhpc-mpich.yml
@@ -6,9 +6,9 @@ name: "NVHPC+MPICH (CPU)"
 on:
   workflow_dispatch:
   push:
-    branches: [master, develop, 'hackathon-*', 'PRtest-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
   pull_request:
-    branches: [master, develop, 'hackathon-*', 'PRtest-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
 
 jobs:
   test:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ on:
       - 'tests/**'
       - '.github/workflows/unit-tests.yml'
   push:
-    branches: [master, develop]
+    branches: [master, develop, 'hotfix-*', 'hotfix/**']
     paths:
       - 'src/**'
       - 'tests/**'


### PR DESCRIPTION
## Summary

- Derive ECT release tags from the MPAS major/minor version so one release,
  such as `ect-v8.4`, supports all `8.4.x` bugfix releases.
- Include the ECT tag in restart cache keys.
- Run CPU ECT, CPU BFB, CUDA compile-only, and unit-test workflows on
  `hotfix-*` and `hotfix/**` branches.
- Add pull-request triggers to the CPU BFB workflows.
- Keep GPU execution workflows manual-only.

## Release data

`ect-v8.4` contains the existing `ect-v8.4.1` data republished under the
series-based name. It includes:

- `120km-spinup-restart.nc.gz`
- `mpas_ect_summary_120km.nc`

Test data and ECT assets continue to be downloaded from
`NCAR/MPAS-Model-CI`.