### PR TITLE
CI: sync workflows from master to develop

### DIFF
--- a/.github/actions/mpas-version/action.yml
+++ b/.github/actions/mpas-version/action.yml
@@ -1,6 +1,7 @@
 name: 'Get MPAS Version'
 description: >
-  Read the MPAS version string from src/core_atmosphere/Registry.xml.
+  Read the MPAS version string from src/core_atmosphere/Registry.xml and
+  derive the major.minor series and ECT data release tag from it.
   Strict — fails the workflow if the file is missing or the version
   attribute cannot be parsed (no silent "unknown" fallback).
 
@@ -14,6 +15,12 @@ outputs:
   version:
     description: 'MPAS version string (e.g., 8.4.0)'
     value: ${{ steps.extract.outputs.version }}
+  version-series:
+    description: 'Major.minor series (e.g., 8.4)'
+    value: ${{ steps.extract.outputs.version-series }}
+  ect-tag:
+    description: 'ECT data release tag for this series (e.g., ect-v8.4)'
+    value: ${{ steps.extract.outputs.ect-tag }}
 
 runs:
   using: 'composite'
@@ -23,6 +30,7 @@ runs:
       run: |
         python3 - "${{ inputs.registry-path }}" <<'PYEOF'
         import os
+        import re
         import sys
         import xml.etree.ElementTree as ET
 
@@ -41,7 +49,19 @@ runs:
             print(f"::error::No version attribute on <registry> in {path}")
             sys.exit(1)
 
+        # ECT data is shared across a major.minor series: ect-v8.4 serves
+        # 8.4.0, 8.4.1, ... so patch releases don't need a new 200-member
+        # ensemble. Regenerate only when the series changes.
+        match = re.match(r'^(\d+)\.(\d+)', version)
+        if not match:
+            print(f"::error::Cannot derive major.minor series from version '{version}'")
+            sys.exit(1)
+        series = f"{match.group(1)}.{match.group(2)}"
+        ect_tag = f"ect-v{series}"
+
         with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
             f.write(f"version={version}\n")
-        print(f"MPAS version: {version}")
+            f.write(f"version-series={series}\n")
+            f.write(f"ect-tag={ect_tag}\n")
+        print(f"MPAS version: {version} (series {series}, ECT tag {ect_tag})")
         PYEOF

--- a/.github/actions/parse-mpas-timers/action.yml
+++ b/.github/actions/parse-mpas-timers/action.yml
@@ -1,0 +1,49 @@
+name: 'Parse MPAS Timers'
+description: >
+  Parse the MPAS-A timer table from log.atmosphere.0000.out into JSON.
+  Works on both CPU and GPU builds
+
+inputs:
+  log-dir:
+    description: 'Directory containing log.atmosphere.0000.out (the run working directory)'
+    required: true
+  log-file:
+    description: 'Log filename within log-dir'
+    required: false
+    default: 'log.atmosphere.0000.out'
+  output-file:
+    description: 'Path to write the parsed JSON'
+    required: true
+
+outputs:
+  json-file:
+    description: 'Path to the parsed timer JSON'
+    value: ${{ steps.parse.outputs.json-file }}
+  timer-count:
+    description: 'Number of timer rows parsed (0 if the table was not found)'
+    value: ${{ steps.parse.outputs.timer-count }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Parse timer table
+      id: parse
+      shell: bash
+      run: |
+        LOG_PATH="${{ inputs.log-dir }}/${{ inputs.log-file }}"
+        OUT="${{ inputs.output-file }}"
+
+        if [ ! -f "${LOG_PATH}" ]; then
+          echo "::error::MPAS log not found at ${LOG_PATH}"
+          exit 1
+        fi
+
+        python3 "${GITHUB_WORKSPACE}/.github/scripts/parse-mpas-timers.py" "${LOG_PATH}" "${OUT}"
+
+        COUNT=$(python3 -c "import json; print(len(json.load(open('${OUT}'))['timers']))")
+        echo "timer-count=${COUNT}" >> "$GITHUB_OUTPUT"
+        echo "json-file=${OUT}" >> "$GITHUB_OUTPUT"
+
+        if [ "${COUNT}" -eq 0 ]; then
+          echo "::warning::No timer rows parsed from ${LOG_PATH} — check that TIMER_LIB was not overridden at build time"
+        fi

--- a/.github/actions/validate-ect/action.yml
+++ b/.github/actions/validate-ect/action.yml
@@ -12,8 +12,8 @@ inputs:
   label:
     description: 'Human-readable label for log annotations (e.g. gcc/mpich3/smiol/4proc)'
     required: true
-  mpas-version:
-    description: 'MPAS version string (used to build the ect-v{version} release tag)'
+  ect-tag:
+    description: 'ECT data release tag (from the mpas-version action, e.g. ect-v8.4)'
     required: true
   dimensions:
     description: 'Multi-line key=value pairs describing this test combination (written into result file)'
@@ -42,12 +42,12 @@ runs:
         fi
         source "${CI_CONFIG}"
 
-        # ECT release tag is derived from the MPAS version (passed in),
-        # not stored in ci-config.env. See .github/actions/mpas-version.
+        # ECT release tag is passed in, not stored in ci-config.env.
+        # See .github/actions/mpas-version.
         echo "summary-file=${ECT_SUMMARY_FILE}" >> $GITHUB_OUTPUT
         echo "pycect-tag=${PYCECT_TAG}" >> $GITHUB_OUTPUT
         echo "pycect-commit=${PYCECT_COMMIT}" >> $GITHUB_OUTPUT
-        echo "release-tag=ect-v${{ inputs.mpas-version }}" >> $GITHUB_OUTPUT
+        echo "release-tag=${{ inputs.ect-tag }}" >> $GITHUB_OUTPUT
 
     - name: Install PyCECT dependencies
       shell: bash

--- a/.github/ci-config.env
+++ b/.github/ci-config.env
@@ -90,13 +90,15 @@ RELEASE_TESTDATA_240KM=testdata-240km-v3
 RELEASE_TESTDATA_120KM=testdata-120km-v2
 
 # ── ECT release tag ──────────────────────────────
-# The ECT release tag (ect-v{MPAS_VERSION}) is derived at runtime from
+# The ECT release tag (ect-v{MAJOR.MINOR}, e.g. ect-v8.4) is derived at runtime from
 # src/core_atmosphere/Registry.xml via the .github/actions/mpas-version
 # composite action. There is no manual tag here — that ensures readers
 # (validate-ect, _test-compiler, _test-gpu, ect-test) and the writer
 # (ect-ensemble-gen) cannot drift out of sync.
 #
-# To publish ECT data for a new MPAS version, run ect-ensemble-gen.yml.
+# One release serves every patch release in a series, so a version bump
+# from 8.4.1 to 8.4.2 reuses ect-v8.4. Run ect-ensemble-gen.yml only when
+# the series changes (8.4 -> 8.5) or the ensemble is invalidated.
 
 
 # ── ECT configuration ────────────────────────────

--- a/.github/scripts/parse-mpas-timers.py
+++ b/.github/scripts/parse-mpas-timers.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Parse the MPAS-A native timer table out of a log.atmosphere.*.out file.
+
+MPAS-A prints a hierarchical timer table by default (TIMER_LIB unset ->
+MPAS_NATIVE_TIMERS, see src/framework/mpas_timer.F: mpas_timer_write). This
+table is emitted on every run, CPU or GPU, and includes per-routine wall-clock
+timers (e.g. atm_advance_acoustic_step, atm_compute_dyn_tend) plus, on
+OpenACC/GPU builds, additional "[ACC_data_xfer]" timers wrapping halo
+exchanges. Parsing this table gives a routine-level CPU vs GPU comparison
+with no source changes required.
+
+Row format (mpas_timer.F, mpas_timer_write):
+    write(msg,'(i2, 1x, a45, f15.5, i10, 3f15.5, 1x, f8.2, 3x, f8.2, 3x, f8.2)')
+        levels, indentation // timer_name, total_time, calls, min_time, max_time,
+        avg_time, pct_tot, pct_par, par_eff
+
+Usage:
+    parse-mpas-timers.py <log-file> <output-json>
+"""
+
+import json
+import re
+import sys
+
+# Level (int) + indented name, then 8 trailing numeric fields:
+#   total(f), calls(i), min(f), max(f), avg(f), pct_tot(f), pct_par(f), par_eff(f)
+# Matched from the right via decimal points rather than fixed columns, since
+# very long/deeply-nested names can overflow their fixed-width field in the
+# Fortran output.
+ROW_RE = re.compile(
+    r"^\s*(?P<level>\d+)\s+(?P<name>.+?)\s+"
+    r"(?P<total>\d+\.\d+)\s+(?P<calls>\d+)\s+"
+    r"(?P<min>\d+\.\d+)\s+(?P<max>\d+\.\d+)\s+(?P<avg>\d+\.\d+)\s+"
+    r"(?P<pct_tot>-?\d+\.\d+)\s+(?P<pct_par>-?\d+\.\d+)\s+(?P<par_eff>-?\d+\.\d+)\s*$"
+)
+
+HEADER_MARKER = "timer_name"
+
+
+def parse_timer_table(text: str) -> list[dict]:
+    lines = text.splitlines()
+
+    # Find the header row so we only parse the table, not incidental matches
+    # elsewhere in the log (there can be per-rank output for multiple ranks;
+    # we intentionally only read rank 0's log, so there is exactly one table).
+    start = None
+    for i, line in enumerate(lines):
+        if HEADER_MARKER in line and "total" in line and "pct_tot" in line:
+            start = i + 1
+            break
+
+    if start is None:
+        return []
+
+    rows = []
+    for line in lines[start:]:
+        if not line.strip():
+            # Native timer table is contiguous; a blank line ends it.
+            if rows:
+                break
+            continue
+        m = ROW_RE.match(line)
+        if not m:
+            # Table ended (next log section began)
+            if rows:
+                break
+            continue
+        rows.append(
+            {
+                "level": int(m.group("level")),
+                "name": m.group("name").strip(),
+                "total_s": float(m.group("total")),
+                "calls": int(m.group("calls")),
+                "min_s": float(m.group("min")),
+                "max_s": float(m.group("max")),
+                "avg_s": float(m.group("avg")),
+                "pct_tot": float(m.group("pct_tot")),
+                "pct_par": float(m.group("pct_par")),
+                "par_eff": float(m.group("par_eff")),
+            }
+        )
+    return rows
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("Usage: parse-mpas-timers.py <log-file> <output-json>", file=sys.stderr)
+        return 2
+
+    log_file, output_json = sys.argv[1], sys.argv[2]
+
+    try:
+        with open(log_file, "r", errors="replace") as f:
+            text = f.read()
+    except FileNotFoundError:
+        print(f"::error::log file not found: {log_file}", file=sys.stderr)
+        return 1
+
+    timers = parse_timer_table(text)
+
+    if not timers:
+        print(f"::warning::no timer table found in {log_file}", file=sys.stderr)
+
+    with open(output_json, "w") as f:
+        json.dump({"source_log": log_file, "timers": timers}, f, indent=2)
+
+    print(f"Parsed {len(timers)} timer rows from {log_file} -> {output_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/summarize-perf.py
+++ b/.github/scripts/summarize-perf.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Combine CPU and GPU MPAS timer JSON (from parse-mpas-timers.py) into:
+  1. A markdown comparison table (written to GITHUB_STEP_SUMMARY by the caller)
+  2. A single structured perf-result.json meant to be the durable record of
+     this run — this is the file a future history/graph step would append
+     to a time series from.
+
+All run metadata is read from environment variables so the workflow doesn't
+need a fragile positional CLI.
+
+Required env vars: CPU_JSON, GPU_JSON, OUT_JSON, OUT_MD
+Optional metadata env vars (all default to "unknown" if unset):
+  REF, SHA, RESOLUTION, RUN_DURATION, COMPILER, MPI,
+  CPU_RANKS, GPU_RANKS, RUNNER_GROUP, RUN_ID, RUN_URL, TARGET_ROUTINE
+"""
+
+import json
+import os
+
+
+def load_timers(path: str) -> dict:
+    with open(path) as f:
+        data = json.load(f)
+    # Keyed by timer name; if a name repeats (shouldn't, but be defensive)
+    # keep the first occurrence.
+    out = {}
+    for row in data.get("timers", []):
+        out.setdefault(row["name"], row)
+    return out
+
+
+def fmt(x, digits=3):
+    return f"{x:.{digits}f}"
+
+
+def main() -> int:
+    cpu_path = os.environ["CPU_JSON"]
+    gpu_path = os.environ["GPU_JSON"]
+    out_json = os.environ["OUT_JSON"]
+    out_md = os.environ["OUT_MD"]
+
+    meta = {
+        "ref": os.environ.get("REF", "unknown"),
+        "sha": os.environ.get("SHA", "unknown"),
+        "resolution": os.environ.get("RESOLUTION", "unknown"),
+        "run_duration": os.environ.get("RUN_DURATION", "unknown"),
+        "compiler": os.environ.get("COMPILER", "unknown"),
+        "mpi": os.environ.get("MPI", "unknown"),
+        "cpu_ranks": os.environ.get("CPU_RANKS", "unknown"),
+        "gpu_ranks": os.environ.get("GPU_RANKS", "unknown"),
+        "runner_group": os.environ.get("RUNNER_GROUP", "unknown"),
+        "run_id": os.environ.get("RUN_ID", "unknown"),
+        "run_url": os.environ.get("RUN_URL", ""),
+        "target_routine": os.environ.get("TARGET_ROUTINE", ""),
+    }
+
+    cpu_timers = load_timers(cpu_path)
+    gpu_timers = load_timers(gpu_path)
+
+    all_names = set(cpu_timers) | set(gpu_timers)
+    comparison = []
+    for name in all_names:
+        c = cpu_timers.get(name)
+        g = gpu_timers.get(name)
+        speedup = None
+        if c and g and g["total_s"] > 0:
+            speedup = c["total_s"] / g["total_s"]
+        comparison.append(
+            {
+                "name": name,
+                "cpu_total_s": c["total_s"] if c else None,
+                "cpu_calls": c["calls"] if c else None,
+                "gpu_total_s": g["total_s"] if g else None,
+                "gpu_calls": g["calls"] if g else None,
+                "speedup_cpu_over_gpu": speedup,
+            }
+        )
+
+    # Sort by whichever side has the larger total time, descending, so the
+    # most expensive routines surface first regardless of which side is slower.
+    def sort_key(row):
+        vals = [v for v in (row["cpu_total_s"], row["gpu_total_s"]) if v is not None]
+        return max(vals) if vals else 0.0
+
+    comparison.sort(key=sort_key, reverse=True)
+
+    result = {
+        "meta": meta,
+        "comparison": comparison,
+        "cpu_timers_full": list(cpu_timers.values()),
+        "gpu_timers_full": list(gpu_timers.values()),
+    }
+
+    with open(out_json, "w") as f:
+        json.dump(result, f, indent=2)
+
+    # --- Markdown summary ---
+    lines = []
+    lines.append("## CPU vs GPU performance (native MPAS timers)")
+    lines.append("")
+    lines.append(
+        f"- **Ref:** `{meta['ref']}` @ `{meta['sha'][:12]}`  "
+        f"- **Resolution:** {meta['resolution']}  "
+        f"- **Run duration:** {meta['run_duration']}"
+    )
+    lines.append(
+        f"- **Compiler/MPI:** {meta['compiler']}/{meta['mpi']}  "
+        f"- **Ranks:** CPU={meta['cpu_ranks']}, GPU={meta['gpu_ranks']}  "
+        f"- **Runner group:** {meta['runner_group']} (same hardware, both legs)"
+    )
+    if meta["target_routine"]:
+        lines.append(f"- **Branch target routine:** `{meta['target_routine']}`")
+    lines.append("")
+    lines.append(
+        "Wall-clock time per named MPAS timer. GPU-only rows (e.g. "
+        "`[ACC_data_xfer]`) have no CPU counterpart and no speedup figure. "
+        "This is not GPU kernel-level granularity — see the routine's own "
+        "notes for a future Nsight-based pass."
+    )
+    lines.append("")
+    lines.append("| Timer | CPU total (s) | GPU total (s) | Speedup (CPU/GPU) |")
+    lines.append("|---|---:|---:|---:|")
+
+    MAX_ROWS = 30
+    shown = comparison[:MAX_ROWS]
+    for row in shown:
+        marker = " **\u2190 target**" if row["name"] == meta["target_routine"] else ""
+        cpu_s = fmt(row["cpu_total_s"]) if row["cpu_total_s"] is not None else "\u2014"
+        gpu_s = fmt(row["gpu_total_s"]) if row["gpu_total_s"] is not None else "\u2014"
+        speedup = f"{row['speedup_cpu_over_gpu']:.2f}\u00d7" if row["speedup_cpu_over_gpu"] else "\u2014"
+        lines.append(f"| `{row['name']}`{marker} | {cpu_s} | {gpu_s} | {speedup} |")
+
+    if len(comparison) > MAX_ROWS:
+        lines.append("")
+        lines.append(
+            f"_{len(comparison) - MAX_ROWS} more timer(s) omitted from this table; "
+            "full data is in the uploaded perf-result.json artifact._"
+        )
+
+    cpu_total = cpu_timers.get("total time", {}).get("total_s")
+    gpu_total = gpu_timers.get("total time", {}).get("total_s")
+    if cpu_total and gpu_total:
+        lines.append("")
+        lines.append(
+            f"**Overall wall time:** CPU {fmt(cpu_total)}s vs GPU {fmt(gpu_total)}s "
+            f"({cpu_total / gpu_total:.2f}\u00d7)"
+        )
+
+    with open(out_md, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+    print(f"Wrote {out_json} and {out_md} ({len(comparison)} timer rows compared)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/_test-compiler.yml
+++ b/.github/workflows/_test-compiler.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.container.outputs.image }}
-      mpas-version: ${{ steps.version.outputs.version }}
+      ect-tag: ${{ steps.version.outputs.ect-tag }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -136,7 +136,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
+          key: ect-spinup-restart-${{ needs.config.outputs.ect-tag }}-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Download spin-up restart
         if: steps.download.outcome == 'success'
@@ -145,7 +145,7 @@ jobs:
         run: |
           source .github/ci-config.env
           RESTART="${ECT_RESTART_FILE}"
-          RELEASE_TAG="ect-v${{ needs.config.outputs.mpas-version }}"
+          RELEASE_TAG="${{ needs.config.outputs.ect-tag }}"
 
           if [ -f "spinup-restart.nc" ]; then
             echo "Using cached restart file"
@@ -223,7 +223,7 @@ jobs:
         with:
           history-dir: ect-test-files
           label: ${{ inputs.compiler }}/${{ inputs.mpi }}/smiol
-          mpas-version: ${{ needs.config.outputs.mpas-version }}
+          ect-tag: ${{ needs.config.outputs.ect-tag }}
           dimensions: |
             compiler=${{ inputs.compiler }}
             mpi=${{ inputs.mpi }}

--- a/.github/workflows/_test-gpu.yml
+++ b/.github/workflows/_test-gpu.yml
@@ -37,7 +37,7 @@ jobs:
     outputs:
       image: ${{ steps.container.outputs.image }}
       image-gpu: ${{ steps.gpu-container.outputs.image }}
-      mpas-version: ${{ steps.version.outputs.version }}
+      ect-tag: ${{ steps.version.outputs.ect-tag }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -152,7 +152,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
+          key: ect-spinup-restart-${{ needs.config.outputs.ect-tag }}-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Download spin-up restart
         if: steps.download.outcome == 'success'
@@ -161,7 +161,7 @@ jobs:
         run: |
           source .github/ci-config.env
           RESTART="${ECT_RESTART_FILE}"
-          RELEASE_TAG="ect-v${{ needs.config.outputs.mpas-version }}"
+          RELEASE_TAG="${{ needs.config.outputs.ect-tag }}"
 
           if [ -f "spinup-restart.nc" ]; then
             echo "Using cached restart file"
@@ -238,7 +238,7 @@ jobs:
         with:
           history-dir: ect-test-files
           label: nvhpc/${{ inputs.mpi }}/cuda/smiol
-          mpas-version: ${{ needs.config.outputs.mpas-version }}
+          ect-tag: ${{ needs.config.outputs.ect-tag }}
           dimensions: |
             compiler=nvhpc
             mpi=${{ inputs.mpi }}

--- a/.github/workflows/_test-perf.yml
+++ b/.github/workflows/_test-perf.yml
@@ -1,0 +1,264 @@
+# Reusable workflow: CPU vs GPU performance comparison.
+#
+# Builds MPAS-A with NVHPC once without OpenACC (CPU) and once with OpenACC
+# (GPU), runs both on the *same* CIRRUS runner group so core count, memory,
+# and node hardware are identical between legs — the only variable is the
+# accelerator. Comparison uses MPAS-A's native per-routine timer table
+# (on by default; see .github/scripts/parse-mpas-timers.py), so no source
+# changes are needed and results are as granular as the model's own
+# instrumentation (e.g. atm_advance_acoustic_step, atm_compute_dyn_tend).
+#
+# This is wall-clock timing only — not GPU kernel-level granularity. A
+# Nsight-based pass for true kernel times is a natural follow-up once this
+# baseline is in use.
+#
+# Security: self-hosted CIRRUS runners. Callers must use workflow_dispatch
+# only, same as _test-gpu.yml and _test-bfb.yml's gpu=true path.
+
+name: _test-perf
+
+permissions:
+  contents: read
+  actions: write
+
+on:
+  workflow_call:
+    inputs:
+      mpi:
+        description: 'MPI implementation (mpich, openmpi)'
+        required: true
+        type: string
+      resolution:
+        description: 'Test case resolution (see RELEASE_TESTDATA_* in ci-config.env)'
+        required: false
+        type: string
+        default: '120km'
+      run-duration:
+        description: 'config_run_duration override (D_HH:MM:SS)'
+        required: false
+        type: string
+        default: '0_00:12:00'
+      cpu-ranks:
+        description: 'MPI rank count for the CPU leg'
+        required: false
+        type: string
+        default: '32'
+      gpu-ranks:
+        description: 'MPI rank count for the GPU leg (typically 1 per GPU on the node)'
+        required: false
+        type: string
+        default: '1'
+      run-timeout:
+        description: 'Run step timeout in minutes (applies to both legs)'
+        required: false
+        type: string
+        default: '30'
+      target-routine:
+        description: >
+          Optional MPAS timer name to call out in the summary (e.g. the routine
+          a hack26_* branch is porting, such as atm_advance_acoustic_step).
+          Purely cosmetic — has no effect on what is measured.
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  config:
+    name: Resolve Config
+    runs-on: ubuntu-latest
+    outputs:
+      image-cpu: ${{ steps.cpu-container.outputs.image }}
+      image-gpu: ${{ steps.gpu-container.outputs.image }}
+      mpas-version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            .github
+            src/core_atmosphere/Registry.xml
+          sparse-checkout-cone-mode: false
+
+      - uses: ./.github/actions/resolve-container
+        id: cpu-container
+        with:
+          compiler: nvhpc
+          mpi: ${{ inputs.mpi }}
+
+      - uses: ./.github/actions/resolve-container
+        id: gpu-container
+        with:
+          compiler: nvhpc
+          mpi: ${{ inputs.mpi }}
+          gpu: cuda
+
+      - uses: ./.github/actions/mpas-version
+        id: version
+
+  build:
+    needs: config
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - leg: cpu
+            openacc: false
+            image: ${{ needs.config.outputs.image-cpu }}
+          - leg: gpu
+            openacc: true
+            image: ${{ needs.config.outputs.image-gpu }}
+    name: Build (${{ matrix.leg }})
+    # Both legs pinned to the same runner group deliberately -- this is
+    # the whole point of the workflow (identical hardware, CPU vs GPU is
+    # the only variable). Not an input; do not make this configurable.
+    runs-on:
+      group: CIRRUS-32x256-A10
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: 'true'
+
+      - name: Build MPAS-A (double precision${{ matrix.openacc && ', OpenACC' || '' }})
+        uses: ./.github/actions/build-mpas
+        with:
+          compiler: nvhpc
+          use-pio: 'false'
+          openacc: ${{ matrix.openacc && 'true' || 'false' }}
+          precision: double
+          build-timeout: '45'
+
+      - name: Upload executable
+        uses: actions/upload-artifact@v6
+        with:
+          name: exe-perf-${{ matrix.leg }}-${{ inputs.mpi }}
+          path: atmosphere_model
+          retention-days: 1
+
+  run:
+    needs: [config, build]
+    if: ${{ needs.build.result == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - leg: cpu
+            openacc: false
+            image: ${{ needs.config.outputs.image-cpu }}
+            ranks: ${{ inputs.cpu-ranks }}
+          - leg: gpu
+            openacc: true
+            image: ${{ needs.config.outputs.image-gpu }}
+            ranks: ${{ inputs.gpu-ranks }}
+    name: Run (${{ matrix.leg }})
+    # Both legs pinned to the same runner group deliberately -- this is
+    # the whole point of the workflow (identical hardware, CPU vs GPU is
+    # the only variable). Not an input; do not make this configurable.
+    runs-on:
+      group: CIRRUS-32x256-A10
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check GPU availability
+        if: ${{ matrix.openacc }}
+        shell: bash
+        run: |
+          echo "=== GPU Information ==="
+          nvidia-smi || echo "::warning::nvidia-smi failed"
+
+      - name: Download executable
+        uses: actions/download-artifact@v7
+        with:
+          name: exe-perf-${{ matrix.leg }}-${{ inputs.mpi }}
+
+      - name: Run MPAS-A
+        uses: ./.github/actions/run-mpas
+        with:
+          executable: ./atmosphere_model
+          num-procs: '${{ matrix.ranks }}'
+          resolution: ${{ inputs.resolution }}
+          run-duration: ${{ inputs.run-duration }}
+          run-timeout: ${{ inputs.run-timeout }}
+          mpi-impl: ${{ inputs.mpi }}
+          working-dir: run-perf-${{ matrix.leg }}
+          strict-exit-check: 'false'
+
+      - name: Parse MPAS timers
+        uses: ./.github/actions/parse-mpas-timers
+        with:
+          log-dir: run-perf-${{ matrix.leg }}
+          output-file: mpas-timers-${{ matrix.leg }}.json
+
+      - name: Upload timer JSON
+        uses: actions/upload-artifact@v6
+        with:
+          name: perf-timers-${{ matrix.leg }}
+          path: mpas-timers-${{ matrix.leg }}.json
+          retention-days: 1
+
+  summarize:
+    needs: [config, run]
+    if: ${{ !cancelled() && needs.run.result == 'success' }}
+    name: Summarize CPU vs GPU
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github
+
+      - name: Download timer JSON (both legs)
+        uses: actions/download-artifact@v7
+        with:
+          pattern: perf-timers-*
+          path: perf-timers
+          merge-multiple: true
+
+      - name: Combine and summarize
+        env:
+          CPU_JSON: perf-timers/mpas-timers-cpu.json
+          GPU_JSON: perf-timers/mpas-timers-gpu.json
+          OUT_JSON: perf-result.json
+          OUT_MD: perf-summary.md
+          REF: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          RESOLUTION: ${{ inputs.resolution }}
+          RUN_DURATION: ${{ inputs.run-duration }}
+          COMPILER: nvhpc
+          MPI: ${{ inputs.mpi }}
+          CPU_RANKS: ${{ inputs.cpu-ranks }}
+          GPU_RANKS: ${{ inputs.gpu-ranks }}
+          RUNNER_GROUP: CIRRUS-32x256-A10
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TARGET_ROUTINE: ${{ inputs.target-routine }}
+        run: |
+          python3 .github/scripts/summarize-perf.py
+          cat perf-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload perf result
+        uses: actions/upload-artifact@v6
+        with:
+          name: perf-result-${{ github.run_id }}
+          path: perf-result.json
+          retention-days: 90
+
+  cleanup:
+    needs: [run, summarize]
+    if: always()
+    runs-on: ubuntu-latest
+    name: Cleanup
+    steps:
+      - name: Delete temporary artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+            --paginate --jq '.artifacts[] | select(.name | startswith("exe-perf-") or startswith("perf-timers-")) | .id' \
+          | while read id; do
+              gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id || true
+            done || true

--- a/.github/workflows/bfb-decomp.yml
+++ b/.github/workflows/bfb-decomp.yml
@@ -6,7 +6,9 @@ name: "BFB: Decomposition (1 vs 4 ranks)"
 on:
   workflow_dispatch:
   push:
-    branches: [hackathon, 'hackathon/**', 'hackathon-*', feature-ci-bfb]
+    branches: [hackathon, 'hackathon/**', 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
+  pull_request:
+    branches: [master, develop, 'hotfix-*', 'hotfix/**']
 
 jobs:
   test:

--- a/.github/workflows/bfb-io.yml
+++ b/.github/workflows/bfb-io.yml
@@ -6,7 +6,9 @@ name: "BFB: I/O (SMIOL vs PIO)"
 on:
   workflow_dispatch:
   push:
-    branches: [hackathon, 'hackathon/**', 'hackathon-*', feature-ci-bfb]
+    branches: [hackathon, 'hackathon/**', 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
+  pull_request:
+    branches: [master, develop, 'hotfix-*', 'hotfix/**']
 
 jobs:
   test:

--- a/.github/workflows/compile-nvhpc-cuda-mpich.yml
+++ b/.github/workflows/compile-nvhpc-cuda-mpich.yml
@@ -9,9 +9,9 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    branches: [master, 'hackathon-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
   pull_request:
-    branches: [master, 'hackathon-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
 
 jobs:
   config:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ on:
         required: false
         default: ''
   push:
-    branches: [master]
+    branches: [master, develop]
 
 jobs:
   config:

--- a/.github/workflows/ect-ensemble-gen.yml
+++ b/.github/workflows/ect-ensemble-gen.yml
@@ -102,6 +102,8 @@ jobs:
     outputs:
       mpas-version: ${{ steps.version.outputs.mpas-version }}
       mpas-commit: ${{ steps.version.outputs.mpas-commit }}
+      version-series: ${{ steps.mpas_version.outputs.version-series }}
+      ect-tag: ${{ steps.mpas_version.outputs.ect-tag }}
     container:
       image: ${{ needs.prepare.outputs.container-image }}
 
@@ -170,7 +172,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
+          key: ect-spinup-restart-${{ needs.build.outputs.ect-tag }}-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Download executable
         if: steps.cache.outputs.cache-hit != 'true'
@@ -212,7 +214,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
+          key: ect-spinup-restart-${{ needs.build.outputs.ect-tag }}-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Upload restart artifact
         uses: actions/upload-artifact@v6
@@ -463,9 +465,9 @@ jobs:
           fi
 
   #===========================================================================
-  # PUBLISH RESTART: Upload spin-up restart to ect-v{MPAS_VERSION}
+  # PUBLISH RESTART: Upload spin-up restart to ect-v{MAJOR.MINOR}
   # Runs after spinup regardless of ensemble/summary outcome.
-  # Auto-creates the release (tagged by MPAS version) if it doesn't exist.
+  # Auto-creates the release (tagged by version series) if it doesn't exist.
   #===========================================================================
   publish-restart:
     needs: [build, spinup]
@@ -491,14 +493,15 @@ jobs:
         run: |
           source .github/ci-config.env
           VERSION="${{ needs.build.outputs.mpas-version }}"
-          TAG="ect-v${VERSION}"
+          SERIES="${{ needs.build.outputs.version-series }}"
+          TAG="${{ needs.build.outputs.ect-tag }}"
 
           # Create release if it doesn't exist
           if ! gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             echo "Creating release ${TAG}..."
             gh release create "${TAG}" --repo "${GITHUB_REPOSITORY}" \
-              --title "ECT data (MPAS v${VERSION})" \
-              --notes "ECT ensemble summary and spin-up restart for MPAS v${VERSION}. Updated automatically by the ect-ensemble-gen workflow."
+              --title "ECT data (MPAS v${SERIES}.x)" \
+              --notes "ECT ensemble summary and spin-up restart shared by all MPAS v${SERIES}.x releases. Generated from v${VERSION}. Updated automatically by the ect-ensemble-gen workflow."
           fi
 
           RESTART_NAME="${ECT_RESTART_FILE}"
@@ -514,9 +517,9 @@ jobs:
           echo "  File: ${RESTART_NAME}.gz ($(du -h "${RESTART_NAME}.gz" | cut -f1))"
 
   #===========================================================================
-  # PUBLISH SUMMARY: Upload ensemble summary to ect-v{MPAS_VERSION}
+  # PUBLISH SUMMARY: Upload ensemble summary to ect-v{MAJOR.MINOR}
   # Only runs when summary generation succeeds.
-  # Auto-creates the release (tagged by MPAS version) if it doesn't exist.
+  # Auto-creates the release (tagged by version series) if it doesn't exist.
   #===========================================================================
   publish-summary:
     needs: [build, generate-summary]
@@ -543,14 +546,15 @@ jobs:
         run: |
           source .github/ci-config.env
           VERSION="${{ needs.build.outputs.mpas-version }}"
-          TAG="ect-v${VERSION}"
+          SERIES="${{ needs.build.outputs.version-series }}"
+          TAG="${{ needs.build.outputs.ect-tag }}"
 
           # Create release if it doesn't exist
           if ! gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             echo "Creating release ${TAG}..."
             gh release create "${TAG}" --repo "${GITHUB_REPOSITORY}" \
-              --title "ECT data (MPAS v${VERSION})" \
-              --notes "ECT ensemble summary and spin-up restart for MPAS v${VERSION}. Updated automatically by the ect-ensemble-gen workflow."
+              --title "ECT data (MPAS v${SERIES}.x)" \
+              --notes "ECT ensemble summary and spin-up restart shared by all MPAS v${SERIES}.x releases. Generated from v${VERSION}. Updated automatically by the ect-ensemble-gen workflow."
           fi
 
           SUMMARY_NAME="${{ needs.generate-summary.outputs.summary-name }}"

--- a/.github/workflows/ect-test.yml
+++ b/.github/workflows/ect-test.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.container.outputs.image }}
-      mpas-version: ${{ steps.version.outputs.version }}
+      ect-tag: ${{ steps.version.outputs.ect-tag }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -124,7 +124,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: spinup-restart.nc
-          key: ect-spinup-restart-${{ hashFiles('.github/ci-config.env') }}
+          key: ect-spinup-restart-${{ needs.config.outputs.ect-tag }}-${{ hashFiles('.github/ci-config.env') }}
 
       - name: Download spin-up restart
         id: restart
@@ -132,7 +132,7 @@ jobs:
         run: |
           source .github/ci-config.env
           RESTART="${ECT_RESTART_FILE}"
-          RELEASE_TAG="ect-v${{ needs.config.outputs.mpas-version }}"
+          RELEASE_TAG="${{ needs.config.outputs.ect-tag }}"
 
           if [ -f "spinup-restart.nc" ]; then
             echo "Using cached restart file"
@@ -213,7 +213,7 @@ jobs:
         with:
           history-dir: ect-test-files
           label: gcc/openmpi/ect-standalone
-          mpas-version: ${{ needs.config.outputs.mpas-version }}
+          ect-tag: ${{ needs.config.outputs.ect-tag }}
 
   #===========================================================================
   # CLEANUP

--- a/.github/workflows/perf-cpu-vs-gpu.yml
+++ b/.github/workflows/perf-cpu-vs-gpu.yml
@@ -1,0 +1,62 @@
+# CPU vs GPU performance comparison on CIRRUS-32x256-A10.
+#
+# Run this from whichever branch you want measured — e.g. a hack26_* routine
+# branch — by picking that branch in the "Run workflow" ref dropdown. Both
+# legs build/run on the same runner group, so the only difference between
+# them is CPU vs GPU (NVHPC + OpenACC).
+#
+# workflow_dispatch only: self-hosted CIRRUS runners must never trigger on
+# push/pull_request (fork / unreviewed-code risk), same as the rest of the
+# GPU test suite.
+
+name: "Perf: CPU vs GPU (NVHPC)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      mpi:
+        description: MPI implementation
+        required: true
+        default: mpich
+        type: choice
+        options:
+          - mpich
+          - openmpi
+      resolution:
+        description: Test case resolution (see RELEASE_TESTDATA_* in ci-config.env)
+        required: false
+        default: '120km'
+        type: string
+      run_duration:
+        description: config_run_duration (D_HH:MM:SS)
+        required: false
+        default: '0_00:12:00'
+        type: string
+      cpu_ranks:
+        description: MPI rank count for the CPU leg
+        required: false
+        default: '32'
+        type: string
+      gpu_ranks:
+        description: MPI rank count for the GPU leg (1 per GPU on the node)
+        required: false
+        default: '1'
+        type: string
+      target_routine:
+        description: >
+          Optional: MPAS timer name to call out in the summary (e.g.
+          atm_advance_acoustic_step). Cosmetic only.
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  perf:
+    uses: ./.github/workflows/_test-perf.yml
+    with:
+      mpi: ${{ inputs.mpi }}
+      resolution: ${{ inputs.resolution }}
+      run-duration: ${{ inputs.run_duration }}
+      cpu-ranks: ${{ inputs.cpu_ranks }}
+      gpu-ranks: ${{ inputs.gpu_ranks }}
+      target-routine: ${{ inputs.target_routine }}

--- a/.github/workflows/test-gcc-mpich.yml
+++ b/.github/workflows/test-gcc-mpich.yml
@@ -6,9 +6,9 @@ name: "GNU+MPICH (CPU)"
 on:
   workflow_dispatch:
   push:
-    branches: [master, 'hackathon-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
   pull_request:
-    branches: [master, 'hackathon-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
 
 jobs:
   test:

--- a/.github/workflows/test-intel-mpich.yml
+++ b/.github/workflows/test-intel-mpich.yml
@@ -6,9 +6,9 @@ name: "Intel+MPICH (CPU)"
 on:
   workflow_dispatch:
   push:
-    branches: [master, 'hackathon-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
   pull_request:
-    branches: [master, 'hackathon-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
 
 jobs:
   test:

--- a/.github/workflows/test-nvhpc-mpich.yml
+++ b/.github/workflows/test-nvhpc-mpich.yml
@@ -6,9 +6,9 @@ name: "NVHPC+MPICH (CPU)"
 on:
   workflow_dispatch:
   push:
-    branches: [master, 'hackathon-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
   pull_request:
-    branches: [master, 'hackathon-*']
+    branches: [master, develop, 'hackathon-*', 'PRtest-*', 'hotfix-*', 'hotfix/**']
 
 jobs:
   test:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ on:
       - 'tests/**'
       - '.github/workflows/unit-tests.yml'
   push:
-    branches: [master]
+    branches: [master, develop, 'hotfix-*', 'hotfix/**']
     paths:
       - 'src/**'
       - 'tests/**'


### PR DESCRIPTION
## Summary

Copy the CI workflows, actions, scripts, and configuration from `master` to
`develop`.

GitHub uses workflow definitions from the base branch for pull-request events.
This allows PRs targeting `develop`, including the v8.4.2 hotfix test, to run
the CI workflows.